### PR TITLE
Improve memory pooling

### DIFF
--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -111,6 +111,10 @@ func BenchmarkOldEngine(b *testing.B) {
 		},
 		{
 			name:  "aggregation",
+			query: "sum(http_requests_total)",
+		},
+		{
+			name:  "aggregation by pod",
 			query: "sum by (pod) (http_requests_total)",
 		},
 		//{

--- a/executionplan/aggregate_table.go
+++ b/executionplan/aggregate_table.go
@@ -85,9 +85,9 @@ func (t *aggregateTable) reset() {
 	}
 }
 
-func (t *aggregateTable) toVector() model.StepVector {
+func (t *aggregateTable) toVector(pool *model.VectorPool) model.StepVector {
 	result := model.StepVector{
-		Samples: make([]model.StepSample, 0, len(t.table)),
+		Samples: pool.GetSamples(),
 	}
 	for _, v := range t.table {
 		if v.accumulator.HasValue() {

--- a/executionplan/concurrent.go
+++ b/executionplan/concurrent.go
@@ -13,6 +13,10 @@ type concurrencyOperator struct {
 	once   sync.Once
 }
 
+func (c *concurrencyOperator) GetPool() *model.VectorPool {
+	return c.next.GetPool()
+}
+
 func concurrent(next VectorOperator) VectorOperator {
 	return &concurrencyOperator{
 		next:   next,

--- a/executionplan/plan.go
+++ b/executionplan/plan.go
@@ -13,34 +13,35 @@ import (
 
 type VectorOperator interface {
 	Next(ctx context.Context) ([]model.StepVector, error)
+	GetPool() *model.VectorPool
 }
 
-func New(expr parser.Expr, storage storage.Queryable, mint, maxt time.Time, step time.Duration) (VectorOperator, error) {
-	pool := model.NewPool()
+func New(expr parser.Expr, pool *model.VectorPool, storage storage.Queryable, mint, maxt time.Time, step time.Duration) (VectorOperator, error) {
 	return newOperator(pool, expr, storage, mint, maxt, step)
 }
 
-func newOperator(pool *model.VectorPool, expr parser.Expr, storage storage.Queryable, mint, maxt time.Time, step time.Duration) (VectorOperator, error) {
+func newOperator(enginePool *model.VectorPool, expr parser.Expr, storage storage.Queryable, mint, maxt time.Time, step time.Duration) (VectorOperator, error) {
 	switch e := expr.(type) {
 	case *parser.AggregateExpr:
-		next, err := newOperator(pool, e.Expr, storage, mint, maxt, step)
+		next, err := newOperator(enginePool, e.Expr, storage, mint, maxt, step)
 		if err != nil {
 			return nil, err
 		}
-		aggregate, err := NewAggregate(pool, next, e.Op, !e.Without, e.Grouping)
+		aggregate, err := NewAggregate(enginePool, next, e.Op, !e.Without, e.Grouping)
 		if err != nil {
 			return nil, err
 		}
 		return concurrent(aggregate), nil
 
 	case *parser.VectorSelector:
+		pool := model.NewPool()
 		filter := newSeriesFilter(storage, mint, maxt, e.LabelMatchers)
 		numShards := 7
 		operators := make([]VectorOperator, 0, numShards)
 		for i := 0; i < numShards; i++ {
 			operators = append(operators, concurrent(NewVectorSelector(pool, filter, mint, maxt, step, i, numShards)))
 		}
-		return coalesce(operators...), nil
+		return coalesce(enginePool, operators...), nil
 
 	//case *parser.Call:
 	//	switch t := e.Args[0].(type) {

--- a/model/pool.go
+++ b/model/pool.go
@@ -5,23 +5,44 @@ import (
 )
 
 type VectorPool struct {
-	pool sync.Pool
+	vectors sync.Pool
+
+	numSamples int
+	samples    sync.Pool
 }
 
 func NewPool() *VectorPool {
-	return &VectorPool{
-		pool: sync.Pool{
-			New: func() any {
-				return make([]StepVector, 0, 30)
-			},
+	pool := &VectorPool{}
+	pool.vectors = sync.Pool{
+		New: func() any {
+			return make([]StepVector, 0, 30)
 		},
 	}
+	pool.samples = sync.Pool{
+		New: func() any {
+			return make([]StepSample, 0, pool.numSamples)
+		},
+	}
+
+	return pool
 }
 
-func (p *VectorPool) Get() []StepVector {
-	return p.pool.Get().([]StepVector)
+func (p *VectorPool) GetVectors() []StepVector {
+	return p.vectors.Get().([]StepVector)
 }
 
-func (p *VectorPool) Put(vector []StepVector) {
-	p.pool.Put(vector[:0])
+func (p *VectorPool) PutVectors(vector []StepVector) {
+	p.vectors.Put(vector[:0])
+}
+
+func (p *VectorPool) GetSamples() []StepSample {
+	return p.samples.Get().([]StepSample)
+}
+
+func (p *VectorPool) PutSamples(samples []StepSample) {
+	p.samples.Put(samples[:0])
+}
+
+func (p *VectorPool) SetStepSamplesSize(n int) {
+	p.numSamples = n
 }


### PR DESCRIPTION
This commit reduces CPU and memory usage by improving pooling of resources.

Each operator gets its own points pool which it uses when allocating memory for each step. The `VectorOperator` interface is also extended with a `GetPool()` method through which the operator can get the pool of its downstream operator. 

Once an operator is finished with processing points from its downstream, it can return those points back to the downstream's pool so they can be reused in subsequent batches.
