### PR TITLE
Precompute output buffers

### DIFF
--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -85,7 +85,7 @@ func BenchmarkSingleQuery(b *testing.B) {
 	end := start.Add(1 * time.Hour)
 	step := time.Second * 30
 
-	query := "sum by (pod) (http_requests_total)"
+	query := "sum(http_requests_total)"
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/engine/range_query.go
+++ b/engine/range_query.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"sort"
+	"sync"
 
 	"github.com/fpetkovski/promql-engine/model"
 
@@ -16,6 +17,7 @@ import (
 type rangeQuery struct {
 	pool *model.VectorPool
 	plan executionplan.VectorOperator
+	once sync.Once
 }
 
 func newRangeQuery(plan executionplan.VectorOperator, pool *model.VectorPool) promql.Query {
@@ -26,7 +28,15 @@ func newRangeQuery(plan executionplan.VectorOperator, pool *model.VectorPool) pr
 }
 
 func (q *rangeQuery) Exec(ctx context.Context) *promql.Result {
-	seriesMap := make(map[uint64]*promql.Series)
+	resultSeries, err := q.plan.Series(ctx)
+	if err != nil {
+		return newErrResult(err)
+	}
+
+	series := make([]promql.Series, len(resultSeries))
+	for i := 0; i < len(resultSeries); i++ {
+		series[i].Metric = resultSeries[i]
+	}
 	for {
 		r, err := q.plan.Next(ctx)
 		if err != nil {
@@ -38,13 +48,10 @@ func (q *rangeQuery) Exec(ctx context.Context) *promql.Result {
 
 		for _, vector := range r {
 			for _, sample := range vector.Samples {
-				if _, ok := seriesMap[sample.ID]; !ok {
-					seriesMap[sample.ID] = &promql.Series{
-						Metric: sample.Metric,
-						Points: make([]promql.Point, 0),
-					}
+				if len(series[sample.ID].Points) == 0 {
+					series[sample.ID].Points = make([]promql.Point, 0, 121)
 				}
-				seriesMap[sample.ID].Points = append(seriesMap[sample.ID].Points, promql.Point{
+				series[sample.ID].Points = append(series[sample.ID].Points, promql.Point{
 					T: vector.T,
 					V: sample.V,
 				})
@@ -54,9 +61,11 @@ func (q *rangeQuery) Exec(ctx context.Context) *promql.Result {
 		q.plan.GetPool().PutVectors(r)
 	}
 
-	result := make(promql.Matrix, 0, len(seriesMap))
-	for _, series := range seriesMap {
-		result = append(result, *series)
+	result := make(promql.Matrix, 0, len(series))
+	for _, s := range series {
+		if len(s.Points) > 0 {
+			result = append(result, s)
+		}
 	}
 
 	sort.Sort(result)

--- a/executionplan/concurrent.go
+++ b/executionplan/concurrent.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 
+	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/fpetkovski/promql-engine/model"
 )
 
@@ -13,15 +15,19 @@ type concurrencyOperator struct {
 	once   sync.Once
 }
 
-func (c *concurrencyOperator) GetPool() *model.VectorPool {
-	return c.next.GetPool()
-}
-
 func concurrent(next VectorOperator, bufferSize int) VectorOperator {
 	return &concurrencyOperator{
 		next:   next,
 		buffer: make(chan []model.StepVector, bufferSize),
 	}
+}
+
+func (c *concurrencyOperator) Series(ctx context.Context) ([]labels.Labels, error) {
+	return c.next.Series(ctx)
+}
+
+func (c *concurrencyOperator) GetPool() *model.VectorPool {
+	return c.next.GetPool()
 }
 
 func (c *concurrencyOperator) Next(ctx context.Context) ([]model.StepVector, error) {


### PR DESCRIPTION
This change allows each operator to precompute its input and output buffers by calling `Series()` on its downstream operators.

Even though precomputing buffers is additional work at the start of the execution, it allows us to:
* allocate memory very precisely
* use arrays instead of maps for lookups
* use very tight loops with no conditional statements

Benchmark before:
```
goos: darwin
goarch: arm64
pkg: github.com/fpetkovski/promql-engine/engine
BenchmarkOldEngine
BenchmarkOldEngine/vector_selector
BenchmarkOldEngine/vector_selector/current_engine
BenchmarkOldEngine/vector_selector/current_engine-8         	      43	  26262838 ns/op	16147712 B/op	   69122 allocs/op
BenchmarkOldEngine/vector_selector/new_engine
BenchmarkOldEngine/vector_selector/new_engine-8             	      36	  33871655 ns/op	37037675 B/op	  104161 allocs/op
BenchmarkOldEngine/aggregation
BenchmarkOldEngine/aggregation/current_engine
BenchmarkOldEngine/aggregation/current_engine-8             	      22	  46908994 ns/op	 4932668 B/op	   73845 allocs/op
BenchmarkOldEngine/aggregation/new_engine
BenchmarkOldEngine/aggregation/new_engine-8                 	      62	  18749468 ns/op	31787828 B/op	  377510 allocs/op
BenchmarkOldEngine/aggregation_by_pod
BenchmarkOldEngine/aggregation_by_pod/current_engine
BenchmarkOldEngine/aggregation_by_pod/current_engine-8      	       8	 130925594 ns/op	87268860 B/op	  568656 allocs/op
BenchmarkOldEngine/aggregation_by_pod/new_engine
BenchmarkOldEngine/aggregation_by_pod/new_engine-8          	      33	  38140593 ns/op	78981717 B/op	 2085462 allocs/op
```

Benchmark after
```
goos: darwin
goarch: arm64
pkg: github.com/fpetkovski/promql-engine/engine
BenchmarkOldEngine
BenchmarkOldEngine/vector_selector
BenchmarkOldEngine/vector_selector/current_engine
BenchmarkOldEngine/vector_selector/current_engine-8         	      43	  26150992 ns/op	16147309 B/op	   69122 allocs/op
BenchmarkOldEngine/vector_selector/new_engine
BenchmarkOldEngine/vector_selector/new_engine-8             	      79	  15771956 ns/op	42044563 B/op	   78790 allocs/op
BenchmarkOldEngine/aggregation
BenchmarkOldEngine/aggregation/current_engine
BenchmarkOldEngine/aggregation/current_engine-8             	      24	  46801087 ns/op	 4931594 B/op	   73844 allocs/op
BenchmarkOldEngine/aggregation/new_engine
BenchmarkOldEngine/aggregation/new_engine-8                 	      94	  13088061 ns/op	26100849 B/op	   74025 allocs/op
BenchmarkOldEngine/aggregation_by_pod
BenchmarkOldEngine/aggregation_by_pod/current_engine
BenchmarkOldEngine/aggregation_by_pod/current_engine-8      	       8	 129737219 ns/op	87268186 B/op	  568653 allocs/op
BenchmarkOldEngine/aggregation_by_pod/new_engine
BenchmarkOldEngine/aggregation_by_pod/new_engine-8          	      76	  15833226 ns/op	38186500 B/op	  161411 allocs/op

```