### PR TITLE
Add vectorized operators

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -11,8 +11,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/thanos-community/promql-engine/physicalplan"
 
-	"github.com/thanos-community/promql-engine/physicalplan/model"
-
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
@@ -21,7 +19,6 @@ import (
 
 type engine struct {
 	logger promql.QueryLogger
-	pool   *model.VectorPool
 
 	lookbackDelta time.Duration
 }
@@ -46,7 +43,6 @@ func New(opts Opts) v1.QueryEngine {
 	}
 
 	core := &engine{
-		pool:          model.NewVectorPool(),
 		lookbackDelta: opts.LookbackDelta,
 	}
 	if opts.DisableFallback {
@@ -124,5 +120,5 @@ func (e *engine) NewRangeQuery(q storage.Queryable, opts *promql.QueryOpts, qs s
 		return nil, err
 	}
 
-	return newRangeQuery(plan, e.pool), nil
+	return newRangeQuery(plan), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.18
 
 require (
 	github.com/efficientgo/core v1.0.0-rc.0
+	github.com/go-kit/log v0.2.1
 	github.com/prometheus/prometheus v0.38.0
+	gonum.org/v1/gonum v0.12.0
 )
 
 require (
@@ -16,7 +18,6 @@ require (
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
-	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
+golang.org/x/exp v0.0.0-20191002040644-a1355ae1e2c3 h1:n9HxLrNxWWtEb1cA950nuEEj3QnKbtsCJ6KjcgisNUs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
@@ -327,6 +328,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gonum.org/v1/gonum v0.12.0 h1:xKuo6hzt+gMav00meVPUlXwSdoEJP46BR+wdxQEFK2o=
+gonum.org/v1/gonum v0.12.0/go.mod h1:73TDxJfAAHeA8Mk9mf8NlIppyhQNo5GLTcYeqgo2lvY=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=

--- a/physicalplan/aggregate/vector_table.go
+++ b/physicalplan/aggregate/vector_table.go
@@ -1,0 +1,85 @@
+package aggregate
+
+import (
+	"fmt"
+
+	"github.com/thanos-community/promql-engine/physicalplan/model"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"gonum.org/v1/gonum/floats"
+)
+
+type vectorAccumulator func([]float64) float64
+
+type vectorTable struct {
+	timestamp   int64
+	value       float64
+	hasValue    bool
+	accumulator vectorAccumulator
+}
+
+func newVectorizedTables(stepsBatch int, a parser.ItemType) ([]aggregateTable, error) {
+	tables := make([]aggregateTable, stepsBatch)
+	for i := 0; i < len(tables); i++ {
+		accumulator, err := newVectorAccumulator(a)
+		if err != nil {
+			return nil, err
+		}
+		tables[i] = newVectorizedTable(accumulator)
+	}
+
+	return tables, nil
+}
+
+func newVectorizedTable(a vectorAccumulator) *vectorTable {
+	return &vectorTable{
+		accumulator: a,
+	}
+}
+
+func (t *vectorTable) aggregate(vector model.StepVector) {
+	if len(vector.SampleIDs) == 0 {
+		t.hasValue = false
+		return
+	}
+	t.hasValue = true
+	t.timestamp = vector.T
+	t.value = t.accumulator(vector.Samples)
+}
+
+func (t *vectorTable) toVector(pool *model.VectorPool) model.StepVector {
+	result := pool.GetStepVector(t.timestamp)
+	if !t.hasValue {
+		return result
+	}
+
+	result.T = t.timestamp
+	result.SampleIDs = append(result.SampleIDs, 0)
+	result.Samples = append(result.Samples, t.value)
+	return result
+}
+
+func (t *vectorTable) size() int {
+	return 1
+}
+
+func newVectorAccumulator(expr parser.ItemType) (vectorAccumulator, error) {
+	t := parser.ItemTypeStr[expr]
+	switch t {
+	case "sum":
+		return floats.Sum, nil
+	case "max":
+		return floats.Max, nil
+	case "min":
+		return floats.Min, nil
+	case "count":
+		return func(float64s []float64) float64 {
+			return float64(len(float64s))
+		}, nil
+	case "avg":
+		return func(in []float64) float64 {
+			return floats.Sum(in) / float64(len(in))
+		}, nil
+	}
+	return nil, fmt.Errorf("unknown aggregation function %s", t)
+}

--- a/physicalplan/exchange/coalesce.go
+++ b/physicalplan/exchange/coalesce.go
@@ -11,6 +11,18 @@ import (
 	"github.com/thanos-community/promql-engine/physicalplan/model"
 )
 
+type errorChan chan error
+
+func (c errorChan) getError() error {
+	for err := range c {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 type coalesceOperator struct {
 	once   sync.Once
 	series []labels.Labels
@@ -39,6 +51,63 @@ func (c *coalesceOperator) Series(ctx context.Context) ([]labels.Labels, error) 
 	return c.series, nil
 }
 
+func (c *coalesceOperator) Next(ctx context.Context) ([]model.StepVector, error) {
+	var out []model.StepVector = nil
+	var wg sync.WaitGroup
+	var mu sync.RWMutex
+	var errChan = make(errorChan, len(c.operators))
+	for _, o := range c.operators {
+		wg.Add(1)
+		go func(o model.VectorOperator) {
+			defer wg.Done()
+
+			in, err := o.Next(ctx)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			if in == nil {
+				return
+			}
+			mu.RLock()
+			if len(in) > 0 && out == nil {
+				mu.RUnlock()
+				mu.Lock()
+				if len(in) > 0 && out == nil {
+					out = c.pool.GetVectorBatch()
+					for i := 0; i < len(in); i++ {
+						out = append(out, c.pool.GetStepVector(in[i].T))
+					}
+				}
+				mu.Unlock()
+			} else {
+				mu.RUnlock()
+			}
+
+			mu.Lock()
+			for i := 0; i < len(in); i++ {
+				out[i].Samples = append(out[i].Samples, in[i].Samples...)
+				out[i].SampleIDs = append(out[i].SampleIDs, in[i].SampleIDs...)
+				o.GetPool().PutStepVector(in[i])
+			}
+			mu.Unlock()
+			o.GetPool().PutVectors(in)
+		}(o)
+	}
+	wg.Wait()
+	close(errChan)
+
+	if err := errChan.getError(); err != nil {
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, nil
+	}
+
+	return out, nil
+}
+
 func (c *coalesceOperator) loadSeries(ctx context.Context) error {
 	size := 0
 	for i := 0; i < len(c.operators); i++ {
@@ -62,40 +131,7 @@ func (c *coalesceOperator) loadSeries(ctx context.Context) error {
 		}
 	}
 	c.series = result
-	c.pool.SetStepSamplesSize(len(c.series))
+	c.pool.SetStepSize(len(c.series))
 
 	return nil
-}
-
-func (c *coalesceOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	var out []model.StepVector = nil
-	for _, o := range c.operators {
-		in, err := o.Next(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if in == nil {
-			continue
-		}
-		if len(in) > 0 && out == nil {
-			out = c.pool.GetVectors()
-			for i := 0; i < len(in); i++ {
-				out = append(out, model.StepVector{
-					T:       in[i].T,
-					Samples: c.pool.GetSamples(),
-				})
-			}
-		}
-
-		for i := 0; i < len(in); i++ {
-			out[i].Samples = append(out[i].Samples, in[i].Samples...)
-			o.GetPool().PutSamples(in[i].Samples)
-		}
-		o.GetPool().PutVectors(in)
-	}
-	if out == nil {
-		return nil, nil
-	}
-
-	return out, nil
 }

--- a/physicalplan/model/vector.go
+++ b/physicalplan/model/vector.go
@@ -5,14 +5,13 @@ package model
 
 import "github.com/prometheus/prometheus/model/labels"
 
-type StepSample struct {
-	ID uint64
-
+type Series struct {
+	ID     uint64
 	Metric labels.Labels
-	V      float64
 }
 
 type StepVector struct {
-	T       int64
-	Samples []StepSample
+	T         int64
+	SampleIDs []uint64
+	Samples   []float64
 }

--- a/physicalplan/scan/vector_selector.go
+++ b/physicalplan/scan/vector_selector.go
@@ -81,7 +81,7 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 	totalSteps := (o.maxt+o.mint)/o.step + 1
 	numSteps := int(math.Min(float64(o.stepsBatch), float64(totalSteps)))
 
-	vectors := o.vectorPool.GetVectors()
+	vectors := o.vectorPool.GetVectorBatch()
 	ts := o.currentStep
 	for i := 0; i < len(o.scanners); i++ {
 		var (
@@ -91,18 +91,12 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 
 		for currStep := 0; currStep < numSteps && seriesTs <= o.maxt; currStep++ {
 			if len(vectors) <= currStep {
-				vectors = append(vectors, model.StepVector{
-					T:       seriesTs,
-					Samples: o.vectorPool.GetSamples(),
-				})
+				vectors = append(vectors, o.vectorPool.GetStepVector(seriesTs))
 			}
 			_, v, ok := selectPoint(series.samples, seriesTs)
 			if ok {
-				vectors[currStep].Samples = append(vectors[currStep].Samples, model.StepSample{
-					ID:     series.signature,
-					Metric: series.labels,
-					V:      v,
-				})
+				vectors[currStep].SampleIDs = append(vectors[currStep].SampleIDs, series.signature)
+				vectors[currStep].Samples = append(vectors[currStep].Samples, v)
 			}
 			seriesTs += o.step
 		}
@@ -131,6 +125,7 @@ func (o *vectorSelector) loadSeries(ctx context.Context) error {
 			}
 			o.series[i] = s.Labels()
 		}
+		o.vectorPool.SetStepSize(len(series))
 	})
 	return err
 }


### PR DESCRIPTION
When aggregating without grouping labels, the aggregation can be done with vectorized assembly operators on the entire step vector.

This commit introduces two aggregation tables as substitute for the old one: scalarTable and vectorizedTable. 
The scalar table uses go code, while the vectorizedTable uses the gonum [floats](https://pkg.go.dev/gonum.org/v1/gonum@v0.12.0/floats) package to execute vectorized aggregations.

Fixes https://github.com/thanos-community/promql-engine/issues/4

<pre>
benchstat old.out new.out 
name                                        old time/op    new time/op    delta
OldEngine/sum/current_engine-4                 123ms ± 0%     122ms ± 0%   ~     (p=1.000 n=1+1)
<strong>OldEngine/sum/new_engine-4                    67.1ms ± 0%    48.9ms ± 0%   ~     (p=1.000 n=1+1)</strong>
OldEngine/sum_rate/current_engine-4            219ms ± 0%     201ms ± 0%   ~     (p=1.000 n=1+1)
<strong>OldEngine/sum_rate/new_engine-4                157ms ± 0%      97ms ± 0%   ~     (p=1.000 n=1+1)</strong>

name                                        old alloc/op   new alloc/op   delta
OldEngine/sum/current_engine-4                4.94MB ± 0%    4.94MB ± 0%   ~     (p=1.000 n=1+1)
<strong>OldEngine/sum/new_engine-4                    18.5MB ± 0%    10.0MB ± 0%   ~     (p=1.000 n=1+1)</strong>
OldEngine/sum_rate/current_engine-4           6.01MB ± 0%    6.01MB ± 0%   ~     (p=1.000 n=1+1)
<strong>OldEngine/sum_rate/new_engine-4               19.0MB ± 0%    12.0MB ± 0%   ~     (p=1.000 n=1+1)</strong>

name                                        old allocs/op  new allocs/op  delta
OldEngine/sum/current_engine-4                 73.8k ± 0%     73.8k ± 0%   ~     (all equal)
OldEngine/sum/new_engine-4                     71.6k ± 0%     73.5k ± 0%   ~     (p=1.000 n=1+1)
OldEngine/sum_rate/current_engine-4            82.9k ± 0%     82.9k ± 0%   ~     (p=1.000 n=1+1)
OldEngine/sum_rate/new_engine-4                98.5k ± 0%    100.4k ± 0%   ~     (p=1.000 n=1+1)
</pre>
