### PR TITLE
Add support for number literals

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -161,6 +161,11 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			load:  "",
 			query: "34",
 		},
+		{
+			name:  "vector",
+			load:  "",
+			query: "vector(24)",
+		},
 	}
 
 	for _, tc := range cases {
@@ -298,6 +303,11 @@ func TestInstantQuery(t *testing.T) {
 			name:  "number literal",
 			load:  "",
 			query: "34",
+		},
+		{
+			name:  "vector",
+			load:  "",
+			query: "vector(24)",
 		},
 	}
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -156,6 +156,11 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			end:   time.Unix(3000, 0),
 			step:  2 * time.Second,
 		},
+		{
+			name:  "number literal",
+			load:  "",
+			query: "34",
+		},
 	}
 
 	for _, tc := range cases {
@@ -288,6 +293,11 @@ func TestInstantQuery(t *testing.T) {
 			name:  "string literal",
 			load:  "",
 			query: `"hello"`,
+		},
+		{
+			name:  "number literal",
+			load:  "",
+			query: "34",
 		},
 	}
 

--- a/engine/instant_query.go
+++ b/engine/instant_query.go
@@ -87,7 +87,7 @@ func (q *instantQuery) Exec(ctx context.Context) *promql.Result {
 			}
 		}
 		result = vector
-	case parser.ValueTypeString:
+	case parser.ValueTypeScalar:
 		result = promql.Scalar{V: series[0].Points[0].V, T: q.ts.UnixMilli()}
 	default:
 		panic(errors.Newf("new.Engine.exec: unexpected expression type %q", q.expr.Type()))

--- a/physicalplan/aggregate/vector_table.go
+++ b/physicalplan/aggregate/vector_table.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
 package aggregate
 
 import (

--- a/physicalplan/plan.go
+++ b/physicalplan/plan.go
@@ -69,6 +69,8 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Ti
 		default:
 			return nil, errors.Wrapf(ErrNotSupportedExpr, "got: %s", t)
 		}
+	case *parser.NumberLiteral:
+		return scan.NewLiteralSelector(model.NewVectorPool(stepsBatch), mint, maxt, step, stepsBatch, e.Val), nil
 	case *parser.StringLiteral:
 		return nil, nil
 	default:

--- a/physicalplan/plan.go
+++ b/physicalplan/plan.go
@@ -70,7 +70,7 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Ti
 			return nil, errors.Wrapf(ErrNotSupportedExpr, "got: %s", t)
 		}
 	case *parser.NumberLiteral:
-		return scan.NewLiteralSelector(model.NewVectorPool(stepsBatch), mint, maxt, step, stepsBatch, e.Val), nil
+		return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), mint, maxt, step, stepsBatch, e.Val), nil
 	case *parser.StringLiteral:
 		return nil, nil
 	default:

--- a/physicalplan/plan.go
+++ b/physicalplan/plan.go
@@ -66,11 +66,18 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Ti
 				operators = append(operators, exchange.NewConcurrent(selector, 2))
 			}
 			return exchange.NewCoalesce(model.NewVectorPool(stepsBatch), operators...), nil
+		case *parser.NumberLiteral:
+			call, err := scan.NewFunctionCall(e.Func, step)
+			if err != nil {
+				return nil, err
+			}
+
+			return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), mint, maxt, step, stepsBatch, t.Val, call), nil
 		default:
 			return nil, errors.Wrapf(ErrNotSupportedExpr, "got: %s", t)
 		}
 	case *parser.NumberLiteral:
-		return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), mint, maxt, step, stepsBatch, e.Val), nil
+		return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), mint, maxt, step, stepsBatch, e.Val, nil), nil
 	case *parser.StringLiteral:
 		return nil, nil
 	default:

--- a/physicalplan/scan/function.go
+++ b/physicalplan/scan/function.go
@@ -69,10 +69,10 @@ func NewFunctionCall(f *parser.Function, selectRange time.Duration) (FunctionCal
 			}
 		}, nil
 	case "vector":
-		return func(_ labels.Labels, points []promql.Point, stepTime time.Time) promql.Sample {
+		return func(labels labels.Labels, points []promql.Point, stepTime time.Time) promql.Sample {
 			return promql.Sample{
 				Point:  points[0],
-				Metric: labels.New(),
+				Metric: labels,
 			}
 		}, nil
 	default:

--- a/physicalplan/scan/function.go
+++ b/physicalplan/scan/function.go
@@ -68,6 +68,13 @@ func NewFunctionCall(f *parser.Function, selectRange time.Duration) (FunctionCal
 				Metric: labels,
 			}
 		}, nil
+	case "vector":
+		return func(_ labels.Labels, points []promql.Point, stepTime time.Time) promql.Sample {
+			return promql.Sample{
+				Point:  points[0],
+				Metric: labels.New(),
+			}
+		}, nil
 	default:
 		return nil, fmt.Errorf("unknown function %s", f.Name)
 	}

--- a/physicalplan/scan/literal_selector.go
+++ b/physicalplan/scan/literal_selector.go
@@ -1,0 +1,78 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package scan
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"github.com/thanos-community/promql-engine/physicalplan/model"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// literalSelector returns []model.StepVector with same sample value across time range.
+type literalSelector struct {
+	vectorPool *model.VectorPool
+
+	mint        int64
+	maxt        int64
+	step        int64
+	currentStep int64
+	stepsBatch  int
+
+	val float64
+}
+
+func NewLiteralSelector(pool *model.VectorPool, mint, maxt time.Time, step time.Duration, stepsBatch int, val float64) model.VectorOperator {
+	return &literalSelector{
+		vectorPool:  pool,
+		mint:        mint.UnixMilli(),
+		maxt:        maxt.UnixMilli(),
+		step:        step.Milliseconds(),
+		currentStep: mint.UnixMilli(),
+		stepsBatch:  stepsBatch,
+		val:         val,
+	}
+}
+
+func (o *literalSelector) Series(ctx context.Context) ([]labels.Labels, error) {
+	return make([]labels.Labels, 1), nil
+}
+
+func (o *literalSelector) GetPool() *model.VectorPool {
+	return o.vectorPool
+}
+
+func (o *literalSelector) Next(ctx context.Context) ([]model.StepVector, error) {
+	if o.currentStep > o.maxt {
+		return nil, nil
+	}
+
+	totalSteps := int64(1)
+	if o.step != 0 {
+		totalSteps = (o.maxt-o.mint)/o.step + 1
+	}
+
+	numSteps := int(math.Min(float64(o.stepsBatch), float64(totalSteps)))
+
+	vectors := o.vectorPool.GetVectorBatch()
+	ts := o.currentStep
+
+	for currStep := 0; currStep < numSteps && ts <= o.maxt; currStep++ {
+		if len(vectors) <= currStep {
+			vectors = append(vectors, o.vectorPool.GetStepVector(ts))
+		}
+
+		vectors[currStep].SampleIDs = append(vectors[currStep].SampleIDs, uint64(0))
+		vectors[currStep].Samples = append(vectors[currStep].Samples, o.val)
+
+		ts += o.step
+	}
+
+	o.currentStep += o.step * int64(numSteps)
+
+	return vectors, nil
+}

--- a/physicalplan/scan/literal_selector.go
+++ b/physicalplan/scan/literal_selector.go
@@ -13,8 +13,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-// literalSelector returns []model.StepVector with same sample value across time range.
-type literalSelector struct {
+// numberLiteralSelector returns []model.StepVector with same sample value across time range.
+type numberLiteralSelector struct {
 	vectorPool *model.VectorPool
 
 	mint        int64
@@ -26,8 +26,8 @@ type literalSelector struct {
 	val float64
 }
 
-func NewLiteralSelector(pool *model.VectorPool, mint, maxt time.Time, step time.Duration, stepsBatch int, val float64) model.VectorOperator {
-	return &literalSelector{
+func NewNumberLiteralSelector(pool *model.VectorPool, mint, maxt time.Time, step time.Duration, stepsBatch int, val float64) model.VectorOperator {
+	return &numberLiteralSelector{
 		vectorPool:  pool,
 		mint:        mint.UnixMilli(),
 		maxt:        maxt.UnixMilli(),
@@ -38,15 +38,15 @@ func NewLiteralSelector(pool *model.VectorPool, mint, maxt time.Time, step time.
 	}
 }
 
-func (o *literalSelector) Series(ctx context.Context) ([]labels.Labels, error) {
+func (o *numberLiteralSelector) Series(ctx context.Context) ([]labels.Labels, error) {
 	return make([]labels.Labels, 1), nil
 }
 
-func (o *literalSelector) GetPool() *model.VectorPool {
+func (o *numberLiteralSelector) GetPool() *model.VectorPool {
 	return o.vectorPool
 }
 
-func (o *literalSelector) Next(ctx context.Context) ([]model.StepVector, error) {
+func (o *numberLiteralSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 	if o.currentStep > o.maxt {
 		return nil, nil
 	}


### PR DESCRIPTION
This PR adds support for number literals in the new engine (for both instant and range queries) as mentioned in #15.
Also adds `vector` function to make it easier to work with in query expressions.