### PR TITLE
Implement binary operator between two vectors

### DIFF
--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -130,6 +130,10 @@ func BenchmarkOldEngineRange(b *testing.B) {
 			name:  "sum by rate",
 			query: "sum by (pod) (rate(http_requests_total[1m]))",
 		},
+		{
+			name:  "binary operation with many to one",
+			query: `http_requests_total / on (pod) group_left http_responses_total`,
+		},
 	}
 
 	for _, tc := range cases {
@@ -207,6 +211,10 @@ func BenchmarkOldEngineInstant(b *testing.B) {
 			name:  "sum by rate",
 			query: "sum by (pod) (rate(http_requests_total[1m]))",
 		},
+		{
+			name:  "binary operation with many to one",
+			query: `http_requests_total / on (pod) group_left http_responses_total`,
+		},
 	}
 
 	for _, tc := range cases {
@@ -275,6 +283,8 @@ load 30s`
 			load += fmt.Sprintf(`
   http_requests_total{pod="p%d", container="c%d"} %d+%dx720`, i, j, i, j)
 		}
+		load += fmt.Sprintf(`
+  http_responses_total{pod="p%d"} %dx720`, i, i)
 	}
 
 	return load

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -207,6 +207,38 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			name:  "vector",
 			load:  "",
 			query: "vector(24)",
+		}, {
+			// Example from https://prometheus.io/docs/prometheus/latest/querying/operators/#many-to-one-and-one-to-many-vector-matches
+			name: "binary operation with group_left",
+			load: `load 30s
+				foo{method="get", code="500"} 1+1.1x30
+				foo{method="get", code="404"} 1+2.2x20
+				foo{method="put", code="501"} 4+3.4x60
+				foo{method="post", code="500"} 1+5.1x40
+				foo{method="post", code="404"} 2+3.7x40
+				bar{method="get", path="/a"} 3+7.4x10
+				bar{method="del", path="/b"} 8+6.1x30  
+				bar{method="post", path="/c"} 1+2.1x40`,
+			query: `foo * ignoring(code, path) group_left bar`,
+			start: time.Unix(0, 0),
+			end:   time.Unix(600, 0),
+		},
+		{
+			// Example from https://prometheus.io/docs/prometheus/latest/querying/operators/#many-to-one-and-one-to-many-vector-matches
+			name: "binary operation with group_right",
+			load: `load 30s
+				foo{method="get", code="500"} 1+1.1x30
+				foo{method="get", code="404"} 1+2.2x20
+				foo{method="put", code="501"} 4+3.4x60
+				foo{method="post", code="500"} 1+5.1x40
+				foo{method="post", code="404"} 2+3.7x40
+				bar{method="get", path="/a"} 3+7.4x10
+				bar{method="del", path="/b"} 8+6.1x30  
+				bar{method="post", path="/c"} 1+2.1x40`,
+			query: `bar * ignoring(code, path) group_right foo`,
+			start: time.Unix(0, 0),
+			end:   time.Unix(3000, 0),
+			step:  2 * time.Second,
 		},
 	}
 

--- a/physicalplan/binary/operator.go
+++ b/physicalplan/binary/operator.go
@@ -1,0 +1,240 @@
+package binary
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/thanos-community/promql-engine/physicalplan/model"
+)
+
+type operator struct {
+	pool *model.VectorPool
+	once sync.Once
+
+	lhs       model.VectorOperator
+	rhs       model.VectorOperator
+	matching  *parser.VectorMatching
+	operation parser.ItemType
+
+	// series contains the output series of the operator
+	series []labels.Labels
+	// The outputCache is an internal cache used to calculate
+	// the binary operation of the lhs and rhs operator.
+	outputCache []sample
+	// highCardOutputIndex is a mapping from series ID of the high cardinality
+	// operator to an output series ID.
+	// The value is nullable since during joins, certain lhs series can fail to
+	// find a matching rhs series.
+	highCardOutputIndex []*uint64
+	// lowCardOutputIndex is a mapping from series ID of the low cardinality
+	// operator to an output series ID.
+	// Each series from the low cardinality operator can join with many
+	// series of the high cardinality operator.
+	lowCardOutputIndex [][]uint64
+	// table is used to calculate the binary operation of two step vectors between
+	// the lhs and rhs operator.
+	table *table
+}
+
+func NewOperator(
+	pool *model.VectorPool,
+	lhs model.VectorOperator,
+	rhs model.VectorOperator,
+	matching *parser.VectorMatching,
+	operation parser.ItemType,
+) (model.VectorOperator, error) {
+	return &operator{
+		pool:      pool,
+		lhs:       lhs,
+		rhs:       rhs,
+		matching:  matching,
+		operation: operation,
+	}, nil
+}
+
+func (o *operator) Series(ctx context.Context) ([]labels.Labels, error) {
+	var err error
+	o.once.Do(func() { err = o.initOutputs(ctx) })
+	if err != nil {
+		return nil, err
+	}
+
+	return o.series, nil
+}
+
+func (o *operator) initOutputs(ctx context.Context) error {
+	// TODO(fpetkovski): execute in parallel
+	highCardSide, err := o.lhs.Series(ctx)
+	if err != nil {
+		return err
+	}
+	lowCardSide, err := o.rhs.Series(ctx)
+	if err != nil {
+		return err
+	}
+	if o.matching.Card == parser.CardOneToMany {
+		highCardSide, lowCardSide = lowCardSide, highCardSide
+	}
+
+	buf := make([]byte, 128)
+	highCardHashes, highCardInputMap := o.hashSeries(highCardSide, true, buf)
+	lowCardHashes, lowCardInputMap := o.hashSeries(lowCardSide, false, buf)
+	output, highCardOutputIndex, lowCardOutputIndex := o.join(highCardHashes, highCardInputMap, lowCardHashes, lowCardInputMap)
+
+	series := make([]labels.Labels, len(output))
+	for _, s := range output {
+		series[s.ID] = s.Metric
+	}
+	o.series = series
+	o.highCardOutputIndex = highCardOutputIndex
+	o.lowCardOutputIndex = lowCardOutputIndex
+	o.outputCache = make([]sample, len(series))
+	o.pool.SetStepSize(len(highCardSide))
+
+	t, err := newTable(o.pool, o.matching.Card, o.operation, o.outputCache, highCardOutputIndex, lowCardOutputIndex)
+	if err != nil {
+		return err
+	}
+	o.table = t
+
+	return nil
+}
+
+func (o *operator) Next(ctx context.Context) ([]model.StepVector, error) {
+	lhs, err := o.lhs.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rhs, err := o.rhs.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(fpetkovski): When one operator becomes empty,
+	// we might want to drain or close the other one.
+	// We don't have a concept of closing an operator yet.
+	if len(lhs) == 0 || len(rhs) == 0 {
+		return nil, nil
+	}
+
+	o.once.Do(func() { err = o.initOutputs(ctx) })
+	if err != nil {
+		return nil, err
+	}
+
+	batch := o.pool.GetVectorBatch()
+	for i, vector := range lhs {
+		step := o.table.execBinaryOperation(lhs[i], rhs[i])
+		batch = append(batch, step)
+		o.lhs.GetPool().PutStepVector(vector)
+		if i < len(rhs) {
+			o.rhs.GetPool().PutStepVector(rhs[i])
+		}
+	}
+	o.lhs.GetPool().PutVectors(lhs)
+	o.rhs.GetPool().PutVectors(rhs)
+
+	return batch, nil
+}
+
+func (o *operator) GetPool() *model.VectorPool {
+	return o.pool
+}
+
+// hashSeries calculates the hash of each series from an input operator.
+// Since series from the high cardinality operator can map to multiple output series,
+// hashSeries returns an index from hash to a slice of resulting series, and
+// a map from input series ID to output series ID.
+// The latter can be used to build an array backed index from input model.Series to output model.Series,
+// avoiding expensive hashmap lookups.
+func (o *operator) hashSeries(series []labels.Labels, keepLabels bool, buf []byte) (map[uint64][]model.Series, map[uint64][]uint64) {
+	hashes := make(map[uint64][]model.Series)
+	inputIndex := make(map[uint64][]uint64)
+	for i, s := range series {
+		sig, lbls := signature(s, !o.matching.On, o.matching.MatchingLabels, keepLabels, buf)
+		if _, ok := hashes[sig]; !ok {
+			hashes[sig] = make([]model.Series, 0, 1)
+			inputIndex[sig] = make([]uint64, 0, 1)
+		}
+		hashes[sig] = append(hashes[sig], model.Series{
+			ID:     uint64(i),
+			Metric: lbls,
+		})
+		inputIndex[sig] = append(inputIndex[sig], uint64(i))
+	}
+
+	return hashes, inputIndex
+}
+
+// join performs a join between series from the high cardinality and low cardinality operators.
+// It does that by using hash maps which point from series hash to the output series.
+// It also returns array backed indices for the high cardinality and low cardinality operators,
+// pointing from input model.Series ID to output model.Series ID.
+// The high cardinality operator can fail to join, which is why its index contains nullable values.
+// The low cardinality operator can join to multiple high cardinality series, which is why its index
+// points to an array of output series.
+func (o *operator) join(
+	highCardHashes map[uint64][]model.Series,
+	highCardInputIndex map[uint64][]uint64,
+	lowCardHashes map[uint64][]model.Series,
+	lowCardInputIndex map[uint64][]uint64,
+) ([]model.Series, []*uint64, [][]uint64) {
+	// Output index points from output series ID
+	// to the actual series.
+	outputIndex := make([]model.Series, 0)
+
+	// Prune high cardinality series which do not have a
+	// matching low cardinality series.
+	outputSize := 0
+	for hash, series := range highCardHashes {
+		outputSize += len(series)
+		if _, ok := lowCardHashes[hash]; !ok {
+			delete(highCardHashes, hash)
+			continue
+		}
+	}
+
+	highCardOutputIndex := make([]*uint64, outputSize)
+	lowCardOutputIndex := make([][]uint64, outputSize)
+	for hash, outputSeries := range highCardHashes {
+		lowCardSeriesID := lowCardInputIndex[hash][0]
+		// Each low cardinality series can map to multiple output series.
+		lowCardOutputIndex[lowCardSeriesID] = make([]uint64, 0, len(outputSeries))
+
+		for i, output := range outputSeries {
+			outputSeries := model.Series{ID: uint64(len(outputIndex)), Metric: output.Metric}
+			outputIndex = append(outputIndex, outputSeries)
+
+			highCardSeriesID := highCardInputIndex[hash][i]
+			highCardOutputIndex[highCardSeriesID] = &outputSeries.ID
+			lowCardOutputIndex[lowCardSeriesID] = append(lowCardOutputIndex[lowCardSeriesID], outputSeries.ID)
+		}
+	}
+
+	return outputIndex, highCardOutputIndex, lowCardOutputIndex
+}
+
+func signature(metric labels.Labels, without bool, grouping []string, keepLabels bool, buf []byte) (uint64, labels.Labels) {
+	buf = buf[:0]
+	lb := labels.NewBuilder(metric).Del(labels.MetricName)
+	if without {
+		dropLabels := append(grouping, labels.MetricName)
+		key, _ := metric.HashWithoutLabels(buf, dropLabels...)
+		if !keepLabels {
+			lb.Del(dropLabels...)
+		}
+		return key, lb.Labels()
+	}
+
+	if keepLabels {
+		lb.Keep(grouping...)
+	}
+	if len(grouping) == 0 {
+		return 0, lb.Labels()
+	}
+
+	key, _ := metric.HashForLabels(buf, grouping...)
+	return key, lb.Labels()
+}

--- a/physicalplan/binary/table.go
+++ b/physicalplan/binary/table.go
@@ -1,0 +1,128 @@
+package binary
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/thanos-community/promql-engine/physicalplan/model"
+)
+
+type sample struct {
+	t int64
+	v float64
+}
+
+type table struct {
+	pool *model.VectorPool
+
+	operation operation
+	card      parser.VectorMatchCardinality
+
+	outputValues        []sample
+	highCardOutputCache []*uint64
+	lowCardOutputCache  [][]uint64
+}
+
+func newTable(
+	pool *model.VectorPool,
+	card parser.VectorMatchCardinality,
+	expr parser.ItemType,
+	outputValues []sample,
+	highCardOutputCache []*uint64,
+	lowCardOutputCache [][]uint64,
+) (*table, error) {
+	op, err := newOperation(expr)
+	if err != nil {
+		return nil, err
+	}
+	return &table{
+		pool: pool,
+		card: card,
+
+		operation:           op,
+		outputValues:        outputValues,
+		highCardOutputCache: highCardOutputCache,
+		lowCardOutputCache:  lowCardOutputCache,
+	}, nil
+}
+
+func (t *table) execBinaryOperation(lhs model.StepVector, rhs model.StepVector) model.StepVector {
+	ts := lhs.T
+	step := t.pool.GetStepVector(ts)
+
+	for i, sampleID := range lhs.SampleIDs {
+		lhsVal := lhs.Samples[i]
+		if t.card == parser.CardOneToMany {
+			outputSampleIDs := t.lowCardOutputCache[sampleID]
+			for _, outputSampleID := range outputSampleIDs {
+				t.outputValues[outputSampleID].t = lhs.T
+				t.outputValues[outputSampleID].v = lhsVal
+			}
+		} else {
+			outputSampleID := t.highCardOutputCache[sampleID]
+			if outputSampleID == nil {
+				continue
+			}
+			t.outputValues[*outputSampleID].t = lhs.T
+			t.outputValues[*outputSampleID].v = lhsVal
+		}
+	}
+
+	for i, sampleID := range rhs.SampleIDs {
+		rhVal := rhs.Samples[i]
+		if t.card == parser.CardManyToOne {
+			outputSampleIDs := t.lowCardOutputCache[sampleID]
+			for _, outputSampleID := range outputSampleIDs {
+				lhSample := t.outputValues[outputSampleID]
+				if rhs.T != lhSample.t {
+					continue
+				}
+
+				outputVal := t.operation(lhSample.v, rhVal)
+				step.SampleIDs = append(step.SampleIDs, outputSampleID)
+				step.Samples = append(step.Samples, outputVal)
+			}
+		} else {
+			outputSampleID := t.highCardOutputCache[sampleID]
+			if outputSampleID == nil {
+				continue
+			}
+			lhSample := t.outputValues[*outputSampleID]
+			if rhs.T != lhSample.t {
+				continue
+			}
+
+			outputVal := t.operation(t.outputValues[*outputSampleID].v, rhVal)
+			step.SampleIDs = append(step.SampleIDs, *outputSampleID)
+			step.Samples = append(step.Samples, outputVal)
+		}
+	}
+
+	return step
+}
+
+type operation func(lhs float64, rhs float64) float64
+
+func newOperation(expr parser.ItemType) (operation, error) {
+	t := parser.ItemTypeStr[expr]
+	switch t {
+	case "+":
+		return func(lhs float64, rhs float64) float64 {
+			return lhs + rhs
+		}, nil
+	case "-":
+		return func(lhs float64, rhs float64) float64 {
+			return lhs - rhs
+		}, nil
+	case "*":
+		return func(lhs float64, rhs float64) float64 {
+			return lhs * rhs
+		}, nil
+	case "/":
+		return func(lhs float64, rhs float64) float64 {
+			return lhs / rhs
+		}, nil
+	default:
+		return nil, fmt.Errorf("operation not supported")
+	}
+}

--- a/physicalplan/binary/table.go
+++ b/physicalplan/binary/table.go
@@ -103,26 +103,17 @@ func (t *table) execBinaryOperation(lhs model.StepVector, rhs model.StepVector) 
 
 type operation func(lhs float64, rhs float64) float64
 
+var operations = map[string]operation{
+	"+": func(lhs float64, rhs float64) float64 { return lhs + rhs },
+	"-": func(lhs float64, rhs float64) float64 { return lhs - rhs },
+	"*": func(lhs float64, rhs float64) float64 { return lhs * rhs },
+	"/": func(lhs float64, rhs float64) float64 { return lhs / rhs },
+}
+
 func newOperation(expr parser.ItemType) (operation, error) {
 	t := parser.ItemTypeStr[expr]
-	switch t {
-	case "+":
-		return func(lhs float64, rhs float64) float64 {
-			return lhs + rhs
-		}, nil
-	case "-":
-		return func(lhs float64, rhs float64) float64 {
-			return lhs - rhs
-		}, nil
-	case "*":
-		return func(lhs float64, rhs float64) float64 {
-			return lhs * rhs
-		}, nil
-	case "/":
-		return func(lhs float64, rhs float64) float64 {
-			return lhs / rhs
-		}, nil
-	default:
-		return nil, fmt.Errorf("operation not supported")
+	if o, ok := operations[t]; ok {
+		return o, nil
 	}
+	return nil, fmt.Errorf("operation not supported")
 }


### PR DESCRIPTION
This commit adds support for binary operations between two vectors. Support for scalar operands and group_left/group_right labels will be added in a follow up PR.

I also tried this in one of our envs, seems to be holding up well so far.
Cannot guarantee lack of dragons.

Benchmark 
```
BenchmarkOldEngineRange
BenchmarkOldEngineRange/binary_operation_with_many_to_one
BenchmarkOldEngineRange/binary_operation_with_many_to_one/current_engine
BenchmarkOldEngineRange/binary_operation_with_many_to_one/current_engine-8         	       3	 381090695 ns/op	63308880 B/op	  594486 allocs/op
BenchmarkOldEngineRange/binary_operation_with_many_to_one/new_engine
BenchmarkOldEngineRange/binary_operation_with_many_to_one/new_engine-8             	      50	  23757462 ns/op	32150253 B/op	  131289 allocs/op
```

cc @yeya24
