### PR TITLE
Implement binary operator with scalar operands

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -240,6 +240,27 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			end:   time.Unix(3000, 0),
 			step:  2 * time.Second,
 		},
+		{
+			name: "binary operation with vector and scalar on the right",
+			load: `load 30s
+				foo{method="get", code="500"} 1+1.1x30
+				foo{method="get", code="404"} 1+2.2x20`,
+			query: `sum(foo) * 2`,
+		},
+		{
+			name: "binary operation with vector and scalar on the left",
+			load: `load 30s
+				foo{method="get", code="500"} 1+1.1x30
+				foo{method="get", code="404"} 1+2.2x20`,
+			query: `2 * sum(foo)`,
+		},
+		{
+			name: "complex binary operation",
+			load: `load 30s
+				foo{method="get", code="500"} 1+1.1x30
+				foo{method="get", code="404"} 1+2.2x20`,
+			query: `1 - (100 * sum(foo{method="get"}) / sum(foo))`,
+		},
 	}
 
 	for _, tc := range cases {
@@ -382,6 +403,27 @@ func TestInstantQuery(t *testing.T) {
 			name:  "vector",
 			load:  "",
 			query: "vector(24)",
+		},
+		{
+			name: "binary operation with vector and scalar on the right",
+			load: `load 30s
+				foo{method="get", code="500"} 1+1.1x30
+				foo{method="get", code="404"} 1+2.2x20`,
+			query: `foo * 2`,
+		},
+		{
+			name: "binary operation with vector and scalar on the left",
+			load: `load 30s
+				foo{method="get", code="500"} 1+1.1x30
+				foo{method="get", code="404"} 1+2.2x20`,
+			query: `2 * foo`,
+		},
+		{
+			name: "complex binary operation",
+			load: `load 30s
+				foo{method="get", code="500"} 1+1.1x30
+				foo{method="get", code="404"} 1+2.2x20`,
+			query: `1 - (100 * sum(foo{method="get"}) / sum(foo))`,
 		},
 	}
 

--- a/physicalplan/binary/scalar.go
+++ b/physicalplan/binary/scalar.go
@@ -1,0 +1,120 @@
+package binary
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/thanos-community/promql-engine/physicalplan/model"
+)
+
+// scalarOperator evaluates expressions where one operand is a scalarOperator.
+type scalarOperator struct {
+	seriesOnce sync.Once
+	series     []labels.Labels
+	scalar     float64
+
+	pool           *model.VectorPool
+	numberSelector model.VectorOperator
+	next           model.VectorOperator
+	getOperands    getOperandsFunc
+	operation      operation
+}
+
+func NewScalar(pool *model.VectorPool, next model.VectorOperator, numberSelector model.VectorOperator, op parser.ItemType, scalarSideLeft bool) (*scalarOperator, error) {
+	binaryOperation, err := newOperation(op)
+	if err != nil {
+		return nil, err
+	}
+	var getOperands getOperandsFunc
+	if scalarSideLeft {
+		getOperands = getOperandsScalarLeft
+	} else {
+		getOperands = getOperandsScalarRight
+	}
+
+	// Cache the result of the number selector since it
+	// will not change during execution.
+	v, err := numberSelector.Next(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	scalar := v[0].Samples[0]
+
+	return &scalarOperator{
+		pool:           pool,
+		next:           next,
+		scalar:         scalar,
+		numberSelector: numberSelector,
+		operation:      binaryOperation,
+		getOperands:    getOperands,
+	}, nil
+}
+
+func (o *scalarOperator) Series(ctx context.Context) ([]labels.Labels, error) {
+	var err error
+	o.seriesOnce.Do(func() { err = o.loadSeries(ctx) })
+	if err != nil {
+		return nil, err
+	}
+	return o.series, nil
+}
+
+func (o *scalarOperator) Next(ctx context.Context) ([]model.StepVector, error) {
+	in, err := o.next.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if in == nil {
+		return nil, nil
+	}
+	o.seriesOnce.Do(func() { err = o.loadSeries(ctx) })
+	if err != nil {
+		return nil, err
+	}
+
+	out := o.pool.GetVectorBatch()
+	for _, vector := range in {
+		step := o.pool.GetStepVector(vector.T)
+		for i := range vector.Samples {
+			lhs, rhs := o.getOperands(vector, i, o.scalar)
+			val := o.operation(lhs, rhs)
+			step.Samples = append(step.Samples, val)
+			step.SampleIDs = append(step.SampleIDs, vector.SampleIDs[i])
+		}
+		out = append(out, step)
+		o.next.GetPool().PutStepVector(vector)
+	}
+	o.next.GetPool().PutVectors(in)
+	return out, nil
+}
+
+func (o *scalarOperator) GetPool() *model.VectorPool {
+	return o.pool
+}
+
+func (o *scalarOperator) loadSeries(ctx context.Context) error {
+	vectorSeries, err := o.next.Series(ctx)
+	if err != nil {
+		return err
+	}
+	series := make([]labels.Labels, len(vectorSeries))
+	for i := range vectorSeries {
+		lbls := labels.NewBuilder(vectorSeries[i]).Del(labels.MetricName).Labels()
+		series[i] = lbls
+	}
+
+	o.series = series
+	return nil
+}
+
+type getOperandsFunc func(v model.StepVector, i int, scalar float64) (float64, float64)
+
+func getOperandsScalarLeft(v model.StepVector, i int, scalar float64) (float64, float64) {
+	return scalar, v.Samples[i]
+}
+
+func getOperandsScalarRight(v model.StepVector, i int, scalar float64) (float64, float64) {
+	return v.Samples[i], scalar
+}

--- a/physicalplan/binary/scalar.go
+++ b/physicalplan/binary/scalar.go
@@ -30,7 +30,7 @@ func NewScalar(pool *model.VectorPool, next model.VectorOperator, numberSelector
 	getOperands := getOperandsScalarRight
 	if scalarSideLeft {
 		getOperands = getOperandsScalarLeft
-	} 
+	}
 
 	// Cache the result of the number selector since it
 	// will not change during execution.

--- a/physicalplan/binary/scalar.go
+++ b/physicalplan/binary/scalar.go
@@ -27,12 +27,10 @@ func NewScalar(pool *model.VectorPool, next model.VectorOperator, numberSelector
 	if err != nil {
 		return nil, err
 	}
-	var getOperands getOperandsFunc
+	getOperands := getOperandsScalarRight
 	if scalarSideLeft {
 		getOperands = getOperandsScalarLeft
-	} else {
-		getOperands = getOperandsScalarRight
-	}
+	} 
 
 	// Cache the result of the number selector since it
 	// will not change during execution.

--- a/physicalplan/plan.go
+++ b/physicalplan/plan.go
@@ -83,24 +83,53 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Ti
 
 	case *parser.BinaryExpr:
 		if e.LHS.Type() == parser.ValueTypeScalar || e.RHS.Type() == parser.ValueTypeScalar {
-			return nil, errors.Wrapf(ErrNotSupportedExpr, "got: %s", e)
+			return newScalarBinaryOperator(e, storage, mint, maxt, step)
 		}
-		if len(e.VectorMatching.Include) > 0 {
-			return nil, errors.Wrapf(ErrNotSupportedExpr, "got: %s", e)
-		}
-		leftOperator, err := newOperator(e.LHS, storage, mint, maxt, step)
-		if err != nil {
-			return nil, err
-		}
-		rightOperator, err := newOperator(e.RHS, storage, mint, maxt, step)
-		if err != nil {
-			return nil, err
-		}
-		return binary.NewOperator(model.NewVectorPool(stepsBatch), leftOperator, rightOperator, e.VectorMatching, e.Op)
+
+		return newVectorBinaryOperator(e, storage, mint, maxt, step)
+
+	case *parser.ParenExpr:
+		return newOperator(e.Expr, storage, mint, maxt, step)
 
 	case *parser.StringLiteral:
 		return nil, nil
 	default:
 		return nil, errors.Wrapf(ErrNotSupportedExpr, "got: %s", e)
 	}
+}
+
+func newVectorBinaryOperator(e *parser.BinaryExpr, storage storage.Queryable, mint time.Time, maxt time.Time, step time.Duration) (model.VectorOperator, error) {
+	if len(e.VectorMatching.Include) > 0 {
+		return nil, errors.Wrapf(ErrNotSupportedExpr, "got: %s", e)
+	}
+
+	leftOperator, err := newOperator(e.LHS, storage, mint, maxt, step)
+	if err != nil {
+		return nil, err
+	}
+	rightOperator, err := newOperator(e.RHS, storage, mint, maxt, step)
+	if err != nil {
+		return nil, err
+	}
+	return binary.NewVectorOperator(model.NewVectorPool(stepsBatch), leftOperator, rightOperator, e.VectorMatching, e.Op)
+}
+
+func newScalarBinaryOperator(e *parser.BinaryExpr, storage storage.Queryable, mint time.Time, maxt time.Time, step time.Duration) (model.VectorOperator, error) {
+	vectorExpr := e.LHS
+	scalarExpr := e.RHS
+	scalarSideLeft := e.LHS.Type() == parser.ValueTypeScalar
+	if scalarSideLeft {
+		scalarExpr, vectorExpr = vectorExpr, scalarExpr
+	}
+
+	vector, err := newOperator(vectorExpr, storage, mint, maxt, step)
+	if err != nil {
+		return nil, err
+	}
+	scalar, err := newOperator(scalarExpr, storage, mint, maxt, step)
+	if err != nil {
+		return nil, err
+	}
+
+	return binary.NewScalar(model.NewVectorPool(stepsBatch), vector, scalar, e.Op, scalarSideLeft)
 }

--- a/physicalplan/plan.go
+++ b/physicalplan/plan.go
@@ -123,7 +123,7 @@ func newScalarBinaryOperator(e *parser.BinaryExpr, storage storage.Queryable, mi
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if e.LHS.Type() == parser.ValueTypeScalar {
 		return binary.NewScalar(model.NewVectorPool(stepsBatch), rhs, lhs, e.Op, true)
 	}

--- a/physicalplan/scan/literal_selector.go
+++ b/physicalplan/scan/literal_selector.go
@@ -101,9 +101,9 @@ func (o *numberLiteralSelector) loadSeries() {
 	// If number literal is included within function, []labels.labels must be initialized.
 	o.once.Do(func() {
 		o.series = make([]labels.Labels, 1)
-
 		if o.call != nil {
 			o.series = []labels.Labels{labels.New()}
 		}
+		o.vectorPool.SetStepSize(len(o.series))
 	})
 }


### PR DESCRIPTION
This commit adds support for the binary operator for cases where one operand is a scalar.

Benchmark:
```
BenchmarkOldEngineRange/binary_operation_with_vector_and_scalar
BenchmarkOldEngineRange/binary_operation_with_vector_and_scalar/current_engine
BenchmarkOldEngineRange/binary_operation_with_vector_and_scalar/current_engine-8   	       5	 234163942 ns/op	30723304 B/op	   84369 allocs/op
BenchmarkOldEngineRange/binary_operation_with_vector_and_scalar/new_engine
BenchmarkOldEngineRange/binary_operation_with_vector_and_scalar/new_engine-8       	      72	  18371273 ns/op	29613023 B/op	   89369 allocs/op
```