### PR TITLE
Improve workers package

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -303,6 +303,7 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 					newEngine := engine.New(engine.Opts{EngineOpts: opts, DisableFallback: disableFallback})
 					q1, err := newEngine.NewRangeQuery(test.Storage(), nil, tc.query, tc.start, tc.end, step)
 					testutil.Ok(t, err)
+
 					newResult := q1.Exec(context.Background())
 					testutil.Ok(t, newResult.Err)
 

--- a/engine/instant_query.go
+++ b/engine/instant_query.go
@@ -37,6 +37,9 @@ func (q *instantQuery) Exec(ctx context.Context) *promql.Result {
 		return &promql.Result{Value: promql.String{V: e.Val, T: q.ts.UnixMilli()}}
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	vs, err := q.plan.Next(ctx)
 	if err != nil {
 		return newErrResult(err)

--- a/engine/range_query.go
+++ b/engine/range_query.go
@@ -27,6 +27,9 @@ func newRangeQuery(plan model.VectorOperator) promql.Query {
 }
 
 func (q *rangeQuery) Exec(ctx context.Context) *promql.Result {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	resultSeries, err := q.plan.Series(ctx)
 	if err != nil {
 		return newErrResult(err)

--- a/physicalplan/scan/literal_selector.go
+++ b/physicalplan/scan/literal_selector.go
@@ -63,6 +63,8 @@ func (o *numberLiteralSelector) Next(ctx context.Context) ([]model.StepVector, e
 	totalSteps := int64(1)
 	if o.step != 0 {
 		totalSteps = (o.maxt-o.mint)/o.step + 1
+	} else {
+		o.step = 1
 	}
 
 	vectors := o.vectorPool.GetVectorBatch()

--- a/physicalplan/scan/literal_selector.go
+++ b/physicalplan/scan/literal_selector.go
@@ -64,6 +64,8 @@ func (o *numberLiteralSelector) Next(ctx context.Context) ([]model.StepVector, e
 	if o.step != 0 {
 		totalSteps = (o.maxt-o.mint)/o.step + 1
 	} else {
+		// For instant queries, set the step to a positive value
+		// so that the operator can terminate.
 		o.step = 1
 	}
 

--- a/physicalplan/scan/matrix_selector.go
+++ b/physicalplan/scan/matrix_selector.go
@@ -100,6 +100,8 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 	totalSteps := int64(1)
 	if o.step != 0 {
 		totalSteps = (o.maxt-o.mint)/o.step + 1
+	} else {
+		o.step = 1
 	}
 	numSteps := int(math.Min(float64(o.stepsBatch), float64(totalSteps)))
 

--- a/physicalplan/scan/matrix_selector.go
+++ b/physicalplan/scan/matrix_selector.go
@@ -101,6 +101,8 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 	if o.step != 0 {
 		totalSteps = (o.maxt-o.mint)/o.step + 1
 	} else {
+		// For instant queries, set the step to a positive value
+		// so that the operator can terminate.
 		o.step = 1
 	}
 	numSteps := int(math.Min(float64(o.stepsBatch), float64(totalSteps)))

--- a/physicalplan/scan/vector_selector.go
+++ b/physicalplan/scan/vector_selector.go
@@ -83,6 +83,8 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 	if o.step != 0 {
 		totalSteps = (o.maxt-o.mint)/o.step + 1
 	} else {
+		// For instant queries, set the step to a positive value
+		// so that the operator can terminate.
 		o.step = 1
 	}
 	numSteps := int(math.Min(float64(o.stepsBatch), float64(totalSteps)))

--- a/physicalplan/scan/vector_selector.go
+++ b/physicalplan/scan/vector_selector.go
@@ -82,8 +82,9 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 	totalSteps := int64(1)
 	if o.step != 0 {
 		totalSteps = (o.maxt-o.mint)/o.step + 1
+	} else {
+		o.step = 1
 	}
-
 	numSteps := int(math.Min(float64(o.stepsBatch), float64(totalSteps)))
 
 	vectors := o.vectorPool.GetVectorBatch()


### PR DESCRIPTION
The workers package uses mutexes for synchronization. This approach was put in place due to concerns related to channel performormance. However, the use of mutexes can leak resources and requires much more careful use of the package.

This commit replaces mutexes with channels and injects a cancellable context when starting a worker group. This way workers will be properly terminated when execution of a query is finished.

Fixes https://github.com/thanos-community/promql-engine/issues/19