### PR TITLE
Extend fallback support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,8 @@ linters-settings:
     locale: US
   goconst:
     min-occurrences: 5
+  goimports:
+    local-prefixes: github.com/thanos-community/promql-engine
 
 issues:
   exclude-rules:

--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+
 	"github.com/thanos-community/promql-engine/engine"
 )
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -9,7 +9,9 @@ import (
 	"github.com/efficientgo/core/errors"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+
 	"github.com/thanos-community/promql-engine/physicalplan"
+	"github.com/thanos-community/promql-engine/physicalplan/parse"
 
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -88,7 +90,7 @@ func (e *engine) SetQueryLogger(l promql.QueryLogger) {
 }
 
 func triggerFallback(err error) bool {
-	return errors.Is(err, physicalplan.ErrNotSupportedExpr) || errors.Is(err, errNotImplemented)
+	return errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, errNotImplemented)
 }
 
 var errNotImplemented = errors.New("not implemented")

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/prometheus/prometheus/promql"
+
 	"github.com/thanos-community/promql-engine/engine"
 )
 

--- a/engine/instant_query.go
+++ b/engine/instant_query.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/efficientgo/core/errors"
+
 	"github.com/thanos-community/promql-engine/physicalplan/model"
 
 	"github.com/prometheus/prometheus/promql"

--- a/physicalplan/aggregate/scalar_table.go
+++ b/physicalplan/aggregate/scalar_table.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+
 	"github.com/thanos-community/promql-engine/physicalplan/model"
 )
 

--- a/physicalplan/binary/scalar.go
+++ b/physicalplan/binary/scalar.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+
 	"github.com/thanos-community/promql-engine/physicalplan/model"
 )
 

--- a/physicalplan/binary/table.go
+++ b/physicalplan/binary/table.go
@@ -6,7 +6,12 @@ package binary
 import (
 	"fmt"
 
+	"github.com/efficientgo/core/errors"
+
+	"github.com/thanos-community/promql-engine/physicalplan/parse"
+
 	"github.com/prometheus/prometheus/promql/parser"
+
 	"github.com/thanos-community/promql-engine/physicalplan/model"
 )
 
@@ -107,5 +112,6 @@ func newOperation(expr parser.ItemType) (operation, error) {
 	if o, ok := operations[t]; ok {
 		return o, nil
 	}
-	return nil, fmt.Errorf("operation not supported")
+	msg := fmt.Sprintf("operation not supported: %s", t)
+	return nil, errors.Wrap(parse.ErrNotSupportedExpr, msg)
 }

--- a/physicalplan/binary/vector.go
+++ b/physicalplan/binary/vector.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+
 	"github.com/thanos-community/promql-engine/physicalplan/model"
 )
 

--- a/physicalplan/exchange/coalesce.go
+++ b/physicalplan/exchange/coalesce.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/thanos-community/promql-engine/physicalplan/model"
 )
 

--- a/physicalplan/parse/errors.go
+++ b/physicalplan/parse/errors.go
@@ -1,0 +1,5 @@
+package parse
+
+import "github.com/efficientgo/core/errors"
+
+var ErrNotSupportedExpr = errors.New("unsupported expression")

--- a/physicalplan/plan.go
+++ b/physicalplan/plan.go
@@ -7,12 +7,11 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/thanos-community/promql-engine/physicalplan/binary"
-
-	"github.com/thanos-community/promql-engine/physicalplan/model"
-
 	"github.com/thanos-community/promql-engine/physicalplan/aggregate"
+	"github.com/thanos-community/promql-engine/physicalplan/binary"
 	"github.com/thanos-community/promql-engine/physicalplan/exchange"
+	"github.com/thanos-community/promql-engine/physicalplan/model"
+	"github.com/thanos-community/promql-engine/physicalplan/parse"
 	"github.com/thanos-community/promql-engine/physicalplan/scan"
 
 	"github.com/efficientgo/core/errors"
@@ -21,8 +20,6 @@ import (
 )
 
 const stepsBatch = 10
-
-var ErrNotSupportedExpr = errors.New("unsupported expression")
 
 // New creates new physical query execution plan for a given query expression.
 func New(expr parser.Expr, storage storage.Queryable, mint, maxt time.Time, step time.Duration) (model.VectorOperator, error) {
@@ -76,7 +73,7 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Ti
 
 			return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), mint, maxt, step, stepsBatch, t.Val, call), nil
 		default:
-			return nil, errors.Wrapf(ErrNotSupportedExpr, "got: %s", t)
+			return nil, errors.Wrapf(parse.ErrNotSupportedExpr, "got: %s", t)
 		}
 	case *parser.NumberLiteral:
 		return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), mint, maxt, step, stepsBatch, e.Val, nil), nil
@@ -94,7 +91,7 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Ti
 	case *parser.StringLiteral:
 		return nil, nil
 	default:
-		return nil, errors.Wrapf(ErrNotSupportedExpr, "got: %s", e)
+		return nil, errors.Wrapf(parse.ErrNotSupportedExpr, "got: %s", e)
 	}
 }
 

--- a/physicalplan/scan/function.go
+++ b/physicalplan/scan/function.go
@@ -8,10 +8,12 @@ import (
 	"math"
 	"time"
 
+	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 
-	"github.com/prometheus/prometheus/promql"
+	"github.com/thanos-community/promql-engine/physicalplan/parse"
 )
 
 type FunctionCall func(labels labels.Labels, points []promql.Point, stepTime time.Time) promql.Sample
@@ -116,7 +118,8 @@ func NewFunctionCall(f *parser.Function, selectRange time.Duration) (FunctionCal
 			}
 		}, nil
 	default:
-		return nil, fmt.Errorf("unknown function %s", f.Name)
+		msg := fmt.Sprintf("unknown function: %s", f.Name)
+		return nil, errors.Wrap(parse.ErrNotSupportedExpr, msg)
 	}
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -5,6 +5,7 @@ package worker
 
 import (
 	"context"
+
 	"github.com/thanos-community/promql-engine/physicalplan/model"
 )
 


### PR DESCRIPTION
This commit adds the ErrNotSupportedExpr to unsupported aggregaion and functions, so that we can properly fall back to the old engine.

It also lints the codebase with goimports.