### PR TITLE
Handle context cancellation

### DIFF
--- a/physicalplan/aggregate/hashaggregate.go
+++ b/physicalplan/aggregate/hashaggregate.go
@@ -94,11 +94,17 @@ func (a *aggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 
 	result := a.vectorPool.GetVectorBatch()
 	for i, vector := range in {
-		a.workers[i].Send(vector)
+		if err := a.workers[i].Send(vector); err != nil {
+			return nil, err
+		}
 	}
 
 	for i, vector := range in {
-		result = append(result, a.workers[i].GetOutput())
+		output, err := a.workers[i].GetOutput()
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, output)
 		a.next.GetPool().PutStepVector(vector)
 	}
 

--- a/physicalplan/exchange/cancellable.go
+++ b/physicalplan/exchange/cancellable.go
@@ -1,0 +1,39 @@
+package exchange
+
+import (
+	"context"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/thanos-community/promql-engine/physicalplan/model"
+)
+
+type CancellableOperator struct {
+	next model.VectorOperator
+}
+
+func NewCancellable(next model.VectorOperator) *CancellableOperator {
+	return &CancellableOperator{next: next}
+}
+
+func (c *CancellableOperator) Next(ctx context.Context) ([]model.StepVector, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		return c.next.Next(ctx)
+	}
+}
+
+func (c *CancellableOperator) Series(ctx context.Context) ([]labels.Labels, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		return c.next.Series(ctx)
+	}
+}
+
+func (c *CancellableOperator) GetPool() *model.VectorPool {
+	return c.next.GetPool()
+}

--- a/physicalplan/plan.go
+++ b/physicalplan/plan.go
@@ -23,29 +23,35 @@ const stepsBatch = 10
 
 // New creates new physical query execution plan for a given query expression.
 func New(expr parser.Expr, storage storage.Queryable, mint, maxt time.Time, step time.Duration) (model.VectorOperator, error) {
-	return newOperator(expr, storage, mint, maxt, step)
+	return newCancellableOperator(expr, storage, mint, maxt, step)
 }
 
-func newOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Time, step time.Duration) (model.VectorOperator, error) {
+func newCancellableOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Time, step time.Duration) (*exchange.CancellableOperator, error) {
+	operator, err := newOperator(expr, storage, mint, maxt, step)
+	if err != nil {
+		return nil, err
+	}
+
+	return exchange.NewCancellable(operator), nil
+}
+
+func newOperator(expr parser.Expr, storage storage.Queryable, mint time.Time, maxt time.Time, step time.Duration) (model.VectorOperator, error) {
 	switch e := expr.(type) {
-	case *parser.AggregateExpr:
-		next, err := newOperator(e.Expr, storage, mint, maxt, step)
-		if err != nil {
-			return nil, err
-		}
-		a, err := aggregate.NewHashAggregate(model.NewVectorPool(stepsBatch), next, e.Op, !e.Without, e.Grouping, stepsBatch)
-		if err != nil {
-			return nil, err
-		}
-		return exchange.NewConcurrent(a, 2), nil
+	case *parser.NumberLiteral:
+		return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), mint, maxt, step, stepsBatch, e.Val, nil), nil
 
 	case *parser.VectorSelector:
 		filter := scan.NewSeriesFilter(storage, mint, maxt, 0, e.LabelMatchers)
 		numShards := runtime.NumCPU() / 2
 		operators := make([]model.VectorOperator, 0, numShards)
 		for i := 0; i < numShards; i++ {
-			operators = append(operators, exchange.NewConcurrent(scan.NewVectorSelector(model.NewVectorPool(stepsBatch), filter, mint, maxt, step, stepsBatch, i, numShards), 2))
+			operator := exchange.NewConcurrent(
+				exchange.NewCancellable(
+					scan.NewVectorSelector(
+						model.NewVectorPool(stepsBatch), filter, mint, maxt, step, stepsBatch, i, numShards)), 2)
+			operators = append(operators, operator)
 		}
+
 		return exchange.NewCoalesce(model.NewVectorPool(stepsBatch), operators...), nil
 
 	case *parser.Call:
@@ -65,9 +71,13 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Ti
 			numShards := runtime.NumCPU() / 2
 			operators := make([]model.VectorOperator, 0, numShards)
 			for i := 0; i < numShards; i++ {
-				selector := scan.NewMatrixSelector(model.NewVectorPool(stepsBatch), filter, e, call, mint, maxt, stepsBatch, step, t.Range, i, numShards)
-				operators = append(operators, exchange.NewConcurrent(selector, 2))
+				operator := exchange.NewConcurrent(
+					exchange.NewCancellable(
+						scan.NewMatrixSelector(
+							model.NewVectorPool(stepsBatch), filter, e, call, mint, maxt, stepsBatch, step, t.Range, i, numShards)), 2)
+				operators = append(operators, operator)
 			}
+
 			return exchange.NewCoalesce(model.NewVectorPool(stepsBatch), operators...), nil
 		case *parser.NumberLiteral:
 			call, err := scan.NewFunctionCall(e.Func, step)
@@ -75,12 +85,25 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Ti
 				return nil, err
 			}
 
-			return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), mint, maxt, step, stepsBatch, t.Val, call), nil
+			return exchange.NewCancellable(
+				scan.NewNumberLiteralSelector(
+					model.NewVectorPool(stepsBatch), mint, maxt, step, stepsBatch, t.Val, call)), nil
 		default:
 			return nil, errors.Wrapf(parse.ErrNotSupportedExpr, "got: %s", t)
 		}
-	case *parser.NumberLiteral:
-		return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), mint, maxt, step, stepsBatch, e.Val, nil), nil
+
+	case *parser.AggregateExpr:
+		next, err := newCancellableOperator(e.Expr, storage, mint, maxt, step)
+		if err != nil {
+			return nil, err
+		}
+
+		a, err := aggregate.NewHashAggregate(model.NewVectorPool(stepsBatch), next, e.Op, !e.Without, e.Grouping, stepsBatch)
+		if err != nil {
+			return nil, err
+		}
+
+		return exchange.NewConcurrent(exchange.NewCancellable(a), 2), nil
 
 	case *parser.BinaryExpr:
 		if e.LHS.Type() == parser.ValueTypeScalar || e.RHS.Type() == parser.ValueTypeScalar {
@@ -90,7 +113,7 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Ti
 		return newVectorBinaryOperator(e, storage, mint, maxt, step)
 
 	case *parser.ParenExpr:
-		return newOperator(e.Expr, storage, mint, maxt, step)
+		return newCancellableOperator(e.Expr, storage, mint, maxt, step)
 
 	case *parser.StringLiteral:
 		return nil, nil
@@ -100,11 +123,11 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Ti
 }
 
 func newVectorBinaryOperator(e *parser.BinaryExpr, storage storage.Queryable, mint time.Time, maxt time.Time, step time.Duration) (model.VectorOperator, error) {
-	leftOperator, err := newOperator(e.LHS, storage, mint, maxt, step)
+	leftOperator, err := newCancellableOperator(e.LHS, storage, mint, maxt, step)
 	if err != nil {
 		return nil, err
 	}
-	rightOperator, err := newOperator(e.RHS, storage, mint, maxt, step)
+	rightOperator, err := newCancellableOperator(e.RHS, storage, mint, maxt, step)
 	if err != nil {
 		return nil, err
 	}
@@ -112,11 +135,11 @@ func newVectorBinaryOperator(e *parser.BinaryExpr, storage storage.Queryable, mi
 }
 
 func newScalarBinaryOperator(e *parser.BinaryExpr, storage storage.Queryable, mint time.Time, maxt time.Time, step time.Duration) (model.VectorOperator, error) {
-	lhs, err := newOperator(e.LHS, storage, mint, maxt, step)
+	lhs, err := newCancellableOperator(e.LHS, storage, mint, maxt, step)
 	if err != nil {
 		return nil, err
 	}
-	rhs, err := newOperator(e.RHS, storage, mint, maxt, step)
+	rhs, err := newCancellableOperator(e.RHS, storage, mint, maxt, step)
 	if err != nil {
 		return nil, err
 	}

--- a/physicalplan/scan/matrix_selector.go
+++ b/physicalplan/scan/matrix_selector.go
@@ -147,7 +147,6 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 	o.currentStep += o.step * int64(numSteps)
 
 	return vectors, nil
-
 }
 
 func (o *matrixSelector) loadSeries(ctx context.Context) error {


### PR DESCRIPTION
The engine will not stop query execution when the query context is
cancelled. This can lead to long-running queries starting to accumulate
in the engine, which in turn can hog resources and create leaks.

This commit introduces a new Cancellable exchange operator which acts
as a middleware and checks if the context has been cancelled before
each step. The commit also makes sure worker channels are closed at the
producer side, so that we don't get "send on closed channel" errors.
