### PR TITLE
support last_over_time function

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ The engine intends to have full compatibility with the original engine used in P
 
 The following table shows operations which are currenly supported by the engine
 
-| Type                   | Supported                                                 | Priority |
-|------------------------|-----------------------------------------------------------|----------|
-| Rate                   | Full support                                              |          |
-| Binary expressions     | Full support                                              |          |
-| Aggregations           | Partial support (sum, max, min, avg and count)            | Medium   |
-| Aggregations over time | Partial support (sum, max, min, avg and count) _over_time | Medium   |
-| Functions              | No support                                                | Medium   |
-| Quantiles              | No support                                                | High     |
+| Type                   | Supported                                                       | Priority |
+|------------------------|-----------------------------------------------------------------|----------|
+| Rate                   | Full support                                                    |          |
+| Binary expressions     | Full support                                                    |          |
+| Aggregations           | Partial support (sum, max, min, avg and count)                  | Medium   |
+| Aggregations over time | Partial support (sum, max, min, avg, count and last) _over_time | Medium   |
+| Functions              | No support                                                      | Medium   |
+| Quantiles              | No support                                                      | High     |
 
 In addition to implementing multi-threading, we would ultimately like to end up with a distributed execution model.
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -326,6 +326,13 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 					http_requests_total{pod="nginx-2"} 1+2x18`,
 			query: `http_requests_total{pod="nginx-3"}`,
 		},
+		{
+			name: "last_over_time",
+			load: `load 30s
+					http_requests_total{pod="nginx-1"} 1+1x15
+					http_requests_total{pod="nginx-2"} 1+2x18`,
+			query: `last_over_time(http_requests_total[30s])`,
+		},
 	}
 
 	for _, tc := range cases {
@@ -507,6 +514,13 @@ func TestInstantQuery(t *testing.T) {
 					http_requests_total{pod="nginx-1"} 1+1x15
 					http_requests_total{pod="nginx-2"} 1+2x18`,
 			query: `http_requests_total{pod="nginx-3"}`,
+		},
+		{
+			name: "last_over_time",
+			load: `load 30s
+					http_requests_total{pod="nginx-1"} 1+1x15
+					http_requests_total{pod="nginx-2"} 1+2x18`,
+			query: `last_over_time(http_requests_total[30s])`,
 		},
 	}
 

--- a/physicalplan/plan.go
+++ b/physicalplan/plan.go
@@ -65,7 +65,7 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Ti
 			numShards := runtime.NumCPU() / 2
 			operators := make([]model.VectorOperator, 0, numShards)
 			for i := 0; i < numShards; i++ {
-				selector := scan.NewMatrixSelector(model.NewVectorPool(stepsBatch), filter, call, mint, maxt, stepsBatch, step, t.Range, i, numShards)
+				selector := scan.NewMatrixSelector(model.NewVectorPool(stepsBatch), filter, e, call, mint, maxt, stepsBatch, step, t.Range, i, numShards)
 				operators = append(operators, exchange.NewConcurrent(selector, 2))
 			}
 			return exchange.NewCoalesce(model.NewVectorPool(stepsBatch), operators...), nil

--- a/physicalplan/scan/function.go
+++ b/physicalplan/scan/function.go
@@ -70,6 +70,16 @@ func NewFunctionCall(f *parser.Function, selectRange time.Duration) (FunctionCal
 				Metric: labels,
 			}
 		}, nil
+	case "last_over_time":
+		return func(labels labels.Labels, points []promql.Point, stepTime time.Time) promql.Sample {
+			return promql.Sample{
+				Point: promql.Point{
+					T: stepTime.UnixMilli(),
+					V: points[len(points)-1].V,
+				},
+				Metric: labels,
+			}
+		}, nil
 	case "rate":
 		return func(labels labels.Labels, points []promql.Point, stepTime time.Time) promql.Sample {
 			point := extrapolatedRate(points, true, true, stepTime, selectRange)

--- a/physicalplan/scan/matrix_selector.go
+++ b/physicalplan/scan/matrix_selector.go
@@ -5,19 +5,18 @@ package scan
 
 import (
 	"context"
-	"github.com/prometheus/prometheus/promql/parser"
 	"math"
 	"sort"
 	"sync"
 	"time"
 
-	"github.com/thanos-community/promql-engine/physicalplan/model"
-
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
-
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
+
+	"github.com/thanos-community/promql-engine/physicalplan/model"
 )
 
 type matrixScanner struct {


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

This pr adds support for `last_over_time` function. 
One thing different is that `last_over_time` requires the metric name to be kept in the final vector result. So I just simply pass the `parser.Call` to the `NewMatrixSelector` to check whether to drop the metric name or not.