### PR TITLE
Use GOMAXPROCS and add benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,12 @@ white-noise-cleanup: ## Cleans up white noise in docs.
 white-noise-cleanup:
 	@echo ">> cleaning up white noise"
 	@find . -type f \( -name "*.md" \) | SED_BIN="$(SED)" xargs scripts/cleanup-white-noise.sh
+
+.PHONY: benchmark
+benchmark:
+	@mkdir -p benchmarks
+	@echo "Benchmarking old engine"
+	@go test ./... -bench 'BenchmarkRangeQuery/.*/old_engine'  -run none -count 10 | sed -u 's/\/old_engine//' > benchmarks/old.out
+	@echo "Benchmarking new engine"
+	@go test ./... -bench 'BenchmarkRangeQuery/.*/new_engine'  -run none -count 10 | sed -u 's/\/new_engine//' > benchmarks/new.out
+	@benchstat benchmarks/old.out benchmarks/new.out

--- a/README.md
+++ b/README.md
@@ -80,65 +80,80 @@ The current implementation uses goroutines very liberally which means the query 
 
 The current implementation creates a physical plan directly from the PromQL abstract syntax tree. Plan optimizations not yet implemented and would require having a logical plan as an intermediary step.
 
-
 ## Latest benchmarks
+
+These are the latest benchmarks captured on an Apple M1 Pro processor.
+
+Note that memory usage is higher when executing a query with parallelism greater than 1. This is due to the fact that the engine is able to execute multiple operations at once (e.g. decode chunks from multiple series at the same time), which requires using independent buffers for each parallel operation. 
 
 Single core benchmarks
 ```markdown
-vector_selector/current_engine         	      44	  27756507 ns/op	16146356 B/op	   69121 allocs/op
-vector_selector/new_engine             	      32	  36515120 ns/op	25709769 B/op	   76738 allocs/op
+name                                                old time/op    new time/op    delta
+RangeQuery/vector_selector                            28.1ms ± 2%    34.2ms ± 4%  +21.80%  (p=0.000 n=9+10)
+RangeQuery/sum                                        46.4ms ± 4%    27.5ms ± 0%  -40.59%  (p=0.000 n=10+10)
+RangeQuery/sum_by_pod                                  134ms ± 2%      37ms ± 0%  -72.72%  (p=0.000 n=10+8)
+RangeQuery/rate                                       52.3ms ± 3%    59.2ms ± 3%  +13.27%  (p=0.000 n=10+10)
+RangeQuery/sum_rate                                   69.8ms ± 3%    53.9ms ± 4%  -22.80%  (p=0.000 n=10+9)
+RangeQuery/sum_by_rate                                 157ms ± 4%      62ms ± 4%  -60.23%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_one_to_one           10.9ms ± 3%     2.4ms ± 4%  -77.58%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_many_to_one           389ms ± 4%      51ms ± 5%  -86.80%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_vector_and_scalar     241ms ± 3%      37ms ± 2%  -84.55%  (p=0.000 n=9+10)
 
-sum/current_engine                     	      22	  47253905 ns/op	 4925751 B/op	   73843 allocs/op
-sum/new_engine                         	      42	  28137694 ns/op	 6933936 B/op	   71399 allocs/op
+name                                                old alloc/op   new alloc/op   delta
+RangeQuery/vector_selector                            16.1MB ± 0%    25.7MB ± 0%  +59.23%  (p=0.000 n=10+10)
+RangeQuery/sum                                        4.93MB ± 0%    6.93MB ± 0%  +40.64%  (p=0.000 n=8+8)
+RangeQuery/sum_by_pod                                 87.3MB ± 0%    16.0MB ± 0%  -81.63%  (p=0.000 n=10+10)
+RangeQuery/rate                                       17.2MB ± 0%    28.2MB ± 0%  +63.65%  (p=0.000 n=10+10)
+RangeQuery/sum_rate                                   5.98MB ± 0%    9.38MB ± 0%  +56.89%  (p=0.000 n=10+9)
+RangeQuery/sum_by_rate                                80.3MB ± 0%    18.4MB ± 0%  -77.11%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_one_to_one           1.64MB ± 0%    2.83MB ± 0%  +72.80%  (p=0.000 n=9+10)
+RangeQuery/binary_operation_with_many_to_one          63.3MB ± 0%    31.4MB ± 0%  -50.39%  (p=0.000 n=10+9)
+RangeQuery/binary_operation_with_vector_and_scalar    30.8MB ± 0%    28.6MB ± 0%   -7.15%  (p=0.000 n=10+10)
 
-sum_by_pod/current_engine              	       8	 135361672 ns/op	87259230 B/op	  568616 allocs/op
-sum_by_pod/new_engine                  	      30	  36838789 ns/op	16031030 B/op	  156454 allocs/op
-
-rate/current_engine                    	      24	  49954635 ns/op	17207644 B/op	   78176 allocs/op
-rate/new_engine                        	      20	  57753527 ns/op	28160190 B/op	  103748 allocs/op
-
-sum_rate/current_engine                	      16	  71503294 ns/op	 5989572 B/op	   82893 allocs/op
-sum_rate/new_engine                    	      20	  53587354 ns/op	 9384271 B/op	   98408 allocs/op
-
-sum_by_rate/current_engine             	       7	 155840905 ns/op	80323640 B/op	  575629 allocs/op
-sum_by_rate/new_engine                 	      18	  62460815 ns/op	18385868 B/op	  183466 allocs/op
-
-binary_operation_with_one_to_one/current_engine         	     100	  10376035 ns/op	 1639915 B/op	   25678 allocs/op
-binary_operation_with_one_to_one/new_engine             	     476	   2454095 ns/op	 2833832 B/op	   20692 allocs/op
-
-binary_operation_with_many_to_one/current_engine        	       3	 391503278 ns/op	63302224 B/op	  594487 allocs/op
-binary_operation_with_many_to_one/new_engine            	      24	  51140486 ns/op	31404253 B/op	  125964 allocs/op
-
-binary_operation_with_vector_and_scalar/current_engine  	       5	 239454433 ns/op	30752913 B/op	   84383 allocs/op
-binary_operation_with_vector_and_scalar/new_engine      	      30	  39809500 ns/op	28554381 B/op	   86641 allocs/op
+name                                                old allocs/op  new allocs/op  delta
+RangeQuery/vector_selector                             69.1k ± 0%     76.7k ± 0%  +11.02%  (p=0.000 n=10+10)
+RangeQuery/sum                                         73.8k ± 0%     71.4k ± 0%   -3.31%  (p=0.000 n=10+9)
+RangeQuery/sum_by_pod                                   569k ± 0%      156k ± 0%  -72.49%  (p=0.000 n=10+8)
+RangeQuery/rate                                        78.2k ± 0%    103.7k ± 0%  +32.71%  (p=0.000 n=9+10)
+RangeQuery/sum_rate                                    82.9k ± 0%     98.4k ± 0%  +18.72%  (p=0.000 n=8+8)
+RangeQuery/sum_by_rate                                  576k ± 0%      183k ± 0%  -68.13%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_one_to_one            25.7k ± 0%     20.7k ± 0%  -19.42%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_many_to_one            594k ± 0%      126k ± 0%  -78.81%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_vector_and_scalar     84.4k ± 0%     86.6k ± 0%   +2.68%  (p=0.000 n=10+10)
 ```
 
 Multi-core (8 core) benchmarks
 ```markdown
-vector_selector/current_engine-8         	      43	  26777890 ns/op	16147463 B/op	   69122 allocs/op
-vector_selector/new_engine-8             	      86	  13340921 ns/op	25779738 B/op	   79186 allocs/op
+name                                                  old time/op    new time/op    delta
+RangeQuery/vector_selector-8                            27.3ms ± 3%    13.7ms ± 3%  -49.94%  (p=0.000 n=10+10)
+RangeQuery/sum-8                                        47.8ms ± 4%     8.9ms ± 7%  -81.44%  (p=0.000 n=10+9)
+RangeQuery/sum_by_pod-8                                  131ms ± 3%      14ms ± 1%  -89.44%  (p=0.000 n=10+10)
+RangeQuery/rate-8                                       49.6ms ± 0%    19.7ms ± 1%  -60.25%  (p=0.000 n=10+9)
+RangeQuery/sum_rate-8                                   70.3ms ± 3%    15.1ms ± 1%  -78.52%  (p=0.000 n=9+10)
+RangeQuery/sum_by_rate-8                                 150ms ± 2%      20ms ± 0%  -86.53%  (p=0.000 n=10+9)
+RangeQuery/binary_operation_with_one_to_one-8           10.4ms ± 4%     1.9ms ± 2%  -82.13%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_many_to_one-8           383ms ± 2%      25ms ± 2%  -93.50%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_vector_and_scalar-8     236ms ± 2%      16ms ± 4%  -93.20%  (p=0.000 n=10+10)
 
-sum/current_engine-8                     	      24	  45773552 ns/op	 4931419 B/op	   73844 allocs/op
-sum/new_engine-8                         	     136	   8681789 ns/op	 7575154 B/op	   73723 allocs/op
+name                                                  old alloc/op   new alloc/op   delta
+RangeQuery/vector_selector-8                            16.1MB ± 0%    25.8MB ± 0%  +59.52%  (p=0.000 n=10+10)
+RangeQuery/sum-8                                        4.93MB ± 0%    7.66MB ± 4%  +55.44%  (p=0.000 n=10+10)
+RangeQuery/sum_by_pod-8                                 87.3MB ± 0%    16.8MB ± 0%  -80.73%  (p=0.000 n=10+10)
+RangeQuery/rate-8                                       17.2MB ± 0%    28.1MB ± 0%  +63.21%  (p=0.000 n=10+10)
+RangeQuery/sum_rate-8                                   5.98MB ± 0%    9.95MB ± 0%  +66.24%  (p=0.000 n=10+10)
+RangeQuery/sum_by_rate-8                                80.3MB ± 0%    18.0MB ± 0%  -77.54%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_one_to_one-8           1.64MB ± 0%    2.61MB ± 1%  +58.84%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_many_to_one-8          63.3MB ± 0%    32.1MB ± 0%  -49.27%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_vector_and_scalar-8    30.8MB ± 0%    29.8MB ± 0%   -3.23%  (p=0.000 n=10+10)
 
-sum_by_pod/current_engine-8              	       8	 129116443 ns/op	87266666 B/op	  568646 allocs/op
-sum_by_pod/new_engine-8                  	      85	  13791413 ns/op	16820641 B/op	  159268 allocs/op
-
-rate/current_engine-8                    	      22	  50682578 ns/op	17210261 B/op	   78177 allocs/op
-rate/new_engine-8                        	      60	  20286784 ns/op	28070821 B/op	  106114 allocs/op
-
-sum_rate/current_engine-8                	      15	  70733758 ns/op	 5985082 B/op	   82892 allocs/op
-sum_rate/new_engine-8                    	      76	  15031830 ns/op	 9937969 B/op	  100705 allocs/op
-
-sum_by_rate/current_engine-8             	       7	 150337315 ns/op	80341581 B/op	  575612 allocs/op
-sum_by_rate/new_engine-8                 	      57	  20519692 ns/op	18097842 B/op	  185775 allocs/op
-
-binary_operation_with_one_to_one/current_engine-8         	     100	  10404304 ns/op	 1640137 B/op	   25678 allocs/op
-binary_operation_with_one_to_one/new_engine-8             	     657	   1809351 ns/op	 2599169 B/op	   21124 allocs/op
-
-binary_operation_with_many_to_one/current_engine-8        	       3	 377181458 ns/op	63306312 B/op	  594488 allocs/op
-binary_operation_with_many_to_one/new_engine-8            	      48	  24788675 ns/op	32035457 B/op	  131273 allocs/op
-
-binary_operation_with_vector_and_scalar/current_engine-8  	       5	 233024283 ns/op	30755686 B/op	   84387 allocs/op
-binary_operation_with_vector_and_scalar/new_engine-8      	      76	  15943312 ns/op	29745027 B/op	   89452 allocs/op
+name                                                  old allocs/op  new allocs/op  delta
+RangeQuery/vector_selector-8                             69.1k ± 0%     79.2k ± 0%  +14.54%  (p=0.000 n=10+10)
+RangeQuery/sum-8                                         73.8k ± 0%     73.8k ± 0%   -0.11%  (p=0.014 n=10+10)
+RangeQuery/sum_by_pod-8                                   569k ± 0%      159k ± 0%  -71.99%  (p=0.000 n=10+10)
+RangeQuery/rate-8                                        78.2k ± 0%    106.1k ± 0%  +35.73%  (p=0.000 n=10+10)
+RangeQuery/sum_rate-8                                    82.9k ± 0%    100.7k ± 0%  +21.49%  (p=0.000 n=7+10)
+RangeQuery/sum_by_rate-8                                  576k ± 0%      186k ± 0%  -67.73%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_one_to_one-8            25.7k ± 0%     21.1k ± 0%  -17.71%  (p=0.000 n=10+10)
+RangeQuery/binary_operation_with_many_to_one-8            594k ± 0%      131k ± 0%  -77.91%  (p=0.000 n=9+10)
+RangeQuery/binary_operation_with_vector_and_scalar-8     84.4k ± 0%     89.5k ± 0%   +6.02%  (p=0.000 n=9+10)
 ```

--- a/README.md
+++ b/README.md
@@ -79,3 +79,66 @@ The current implementation uses goroutines very liberally which means the query 
 ### Plan optimization
 
 The current implementation creates a physical plan directly from the PromQL abstract syntax tree. Plan optimizations not yet implemented and would require having a logical plan as an intermediary step.
+
+
+## Latest benchmarks
+
+Single core benchmarks
+```markdown
+vector_selector/current_engine         	      44	  27756507 ns/op	16146356 B/op	   69121 allocs/op
+vector_selector/new_engine             	      32	  36515120 ns/op	25709769 B/op	   76738 allocs/op
+
+sum/current_engine                     	      22	  47253905 ns/op	 4925751 B/op	   73843 allocs/op
+sum/new_engine                         	      42	  28137694 ns/op	 6933936 B/op	   71399 allocs/op
+
+sum_by_pod/current_engine              	       8	 135361672 ns/op	87259230 B/op	  568616 allocs/op
+sum_by_pod/new_engine                  	      30	  36838789 ns/op	16031030 B/op	  156454 allocs/op
+
+rate/current_engine                    	      24	  49954635 ns/op	17207644 B/op	   78176 allocs/op
+rate/new_engine                        	      20	  57753527 ns/op	28160190 B/op	  103748 allocs/op
+
+sum_rate/current_engine                	      16	  71503294 ns/op	 5989572 B/op	   82893 allocs/op
+sum_rate/new_engine                    	      20	  53587354 ns/op	 9384271 B/op	   98408 allocs/op
+
+sum_by_rate/current_engine             	       7	 155840905 ns/op	80323640 B/op	  575629 allocs/op
+sum_by_rate/new_engine                 	      18	  62460815 ns/op	18385868 B/op	  183466 allocs/op
+
+binary_operation_with_one_to_one/current_engine         	     100	  10376035 ns/op	 1639915 B/op	   25678 allocs/op
+binary_operation_with_one_to_one/new_engine             	     476	   2454095 ns/op	 2833832 B/op	   20692 allocs/op
+
+binary_operation_with_many_to_one/current_engine        	       3	 391503278 ns/op	63302224 B/op	  594487 allocs/op
+binary_operation_with_many_to_one/new_engine            	      24	  51140486 ns/op	31404253 B/op	  125964 allocs/op
+
+binary_operation_with_vector_and_scalar/current_engine  	       5	 239454433 ns/op	30752913 B/op	   84383 allocs/op
+binary_operation_with_vector_and_scalar/new_engine      	      30	  39809500 ns/op	28554381 B/op	   86641 allocs/op
+```
+
+Multi-core (8 core) benchmarks
+```markdown
+vector_selector/current_engine-8         	      43	  26777890 ns/op	16147463 B/op	   69122 allocs/op
+vector_selector/new_engine-8             	      86	  13340921 ns/op	25779738 B/op	   79186 allocs/op
+
+sum/current_engine-8                     	      24	  45773552 ns/op	 4931419 B/op	   73844 allocs/op
+sum/new_engine-8                         	     136	   8681789 ns/op	 7575154 B/op	   73723 allocs/op
+
+sum_by_pod/current_engine-8              	       8	 129116443 ns/op	87266666 B/op	  568646 allocs/op
+sum_by_pod/new_engine-8                  	      85	  13791413 ns/op	16820641 B/op	  159268 allocs/op
+
+rate/current_engine-8                    	      22	  50682578 ns/op	17210261 B/op	   78177 allocs/op
+rate/new_engine-8                        	      60	  20286784 ns/op	28070821 B/op	  106114 allocs/op
+
+sum_rate/current_engine-8                	      15	  70733758 ns/op	 5985082 B/op	   82892 allocs/op
+sum_rate/new_engine-8                    	      76	  15031830 ns/op	 9937969 B/op	  100705 allocs/op
+
+sum_by_rate/current_engine-8             	       7	 150337315 ns/op	80341581 B/op	  575612 allocs/op
+sum_by_rate/new_engine-8                 	      57	  20519692 ns/op	18097842 B/op	  185775 allocs/op
+
+binary_operation_with_one_to_one/current_engine-8         	     100	  10404304 ns/op	 1640137 B/op	   25678 allocs/op
+binary_operation_with_one_to_one/new_engine-8             	     657	   1809351 ns/op	 2599169 B/op	   21124 allocs/op
+
+binary_operation_with_many_to_one/current_engine-8        	       3	 377181458 ns/op	63306312 B/op	  594488 allocs/op
+binary_operation_with_many_to_one/new_engine-8            	      48	  24788675 ns/op	32035457 B/op	  131273 allocs/op
+
+binary_operation_with_vector_and_scalar/current_engine-8  	       5	 233024283 ns/op	30755686 B/op	   84387 allocs/op
+binary_operation_with_vector_and_scalar/new_engine-8      	      76	  15943312 ns/op	29745027 B/op	   89452 allocs/op
+```

--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -96,7 +96,7 @@ func BenchmarkSingleQuery(b *testing.B) {
 	}
 }
 
-func BenchmarkOldEngineRange(b *testing.B) {
+func BenchmarkRangeQuery(b *testing.B) {
 	test := setupStorage(b, 1000, 3)
 	defer test.Close()
 
@@ -148,7 +148,7 @@ func BenchmarkOldEngineRange(b *testing.B) {
 
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
-			b.Run("current_engine", func(b *testing.B) {
+			b.Run("old_engine", func(b *testing.B) {
 				opts := promql.EngineOpts{
 					Logger:     nil,
 					Reg:        nil,

--- a/physicalplan/plan.go
+++ b/physicalplan/plan.go
@@ -42,7 +42,10 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint time.Time, ma
 
 	case *parser.VectorSelector:
 		filter := scan.NewSeriesFilter(storage, mint, maxt, 0, e.LabelMatchers)
-		numShards := runtime.NumCPU() / 2
+		numShards := runtime.GOMAXPROCS(0) / 2
+		if numShards < 1 {
+			numShards = 1
+		}
 		operators := make([]model.VectorOperator, 0, numShards)
 		for i := 0; i < numShards; i++ {
 			operator := exchange.NewConcurrent(
@@ -68,7 +71,10 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint time.Time, ma
 			}
 
 			filter := scan.NewSeriesFilter(storage, mint, maxt, t.Range, vs.LabelMatchers)
-			numShards := runtime.NumCPU() / 2
+			numShards := runtime.GOMAXPROCS(0) / 2
+			if numShards < 1 {
+				numShards = 1
+			}
 			operators := make([]model.VectorOperator, 0, numShards)
 			for i := 0; i < numShards; i++ {
 				operator := exchange.NewConcurrent(


### PR DESCRIPTION
We use runtime.NumCPU to determine parallelism, which can create issues in containerized environments.

This commit changes the planner to use `GOMAXPROCS` instead. It also adds information from the latest benchmarks.