### PR TITLE
Validate binary operator at creation time

### DIFF
--- a/physicalplan/binary/table.go
+++ b/physicalplan/binary/table.go
@@ -42,24 +42,20 @@ type table struct {
 func newTable(
 	pool *model.VectorPool,
 	card parser.VectorMatchCardinality,
-	expr parser.ItemType,
+	operation operation,
 	outputValues []sample,
 	highCardOutputCache outputIndex,
 	lowCardOutputCache outputIndex,
-) (*table, error) {
-	op, err := newOperation(expr)
-	if err != nil {
-		return nil, err
-	}
+) *table {
 	return &table{
 		pool: pool,
 		card: card,
 
-		operation:           op,
+		operation:           operation,
 		outputValues:        outputValues,
 		highCardOutputIndex: highCardOutputCache,
 		lowCardOutputIndex:  lowCardOutputCache,
-	}, nil
+	}
 }
 
 func (t *table) execBinaryOperation(lhs model.StepVector, rhs model.StepVector) model.StepVector {

--- a/physicalplan/binary/vector.go
+++ b/physicalplan/binary/vector.go
@@ -21,7 +21,7 @@ type vectorOperator struct {
 	lhs       model.VectorOperator
 	rhs       model.VectorOperator
 	matching  *parser.VectorMatching
-	operation parser.ItemType
+	operation operation
 
 	// series contains the output series of the operator
 	series []labels.Labels
@@ -40,12 +40,16 @@ func NewVectorOperator(
 	matching *parser.VectorMatching,
 	operation parser.ItemType,
 ) (model.VectorOperator, error) {
+	op, err := newOperation(operation)
+	if err != nil {
+		return nil, err
+	}
 	return &vectorOperator{
 		pool:      pool,
 		lhs:       lhs,
 		rhs:       rhs,
 		matching:  matching,
-		operation: operation,
+		operation: op,
 	}, nil
 }
 
@@ -95,7 +99,7 @@ func (o *vectorOperator) initOutputs(ctx context.Context) error {
 	}
 	o.pool.SetStepSize(len(highCardSide))
 
-	t, err := newTable(
+	o.table = newTable(
 		o.pool,
 		o.matching.Card,
 		o.operation,
@@ -103,10 +107,6 @@ func (o *vectorOperator) initOutputs(ctx context.Context) error {
 		newHighCardIndex(highCardOutputIndex),
 		lowCardinalityIndex(lowCardOutputIndex),
 	)
-	if err != nil {
-		return err
-	}
-	o.table = t
 
 	return nil
 }


### PR DESCRIPTION
This commit moves validation for the binary operator at creation time, so that we can use the fallback mechanism for unsupported operators.