### PR TITLE
Support lookbackdelta

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -101,7 +101,7 @@ func (e *engine) NewInstantQuery(q storage.Queryable, opts *promql.QueryOpts, qs
 		return nil, err
 	}
 
-	plan, err := physicalplan.New(expr, q, ts, ts, 0)
+	plan, err := physicalplan.New(expr, q, ts, ts, 0, e.lookbackDelta)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (e *engine) NewRangeQuery(q storage.Queryable, opts *promql.QueryOpts, qs s
 		return nil, errors.Newf("invalid expression type %q for range query, must be Scalar or instant Vector", parser.DocumentedType(expr.Type()))
 	}
 
-	plan, err := physicalplan.New(expr, q, start, end, interval)
+	plan, err := physicalplan.New(expr, q, start, end, interval, e.lookbackDelta)
 	if err != nil {
 		return nil, err
 	}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -440,7 +440,7 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 		},
 	}
 
-	lookbackDeltas := []time.Duration{time.Minute, 5 * time.Minute, 10 * time.Minute}
+	lookbackDeltas := []time.Duration{30 * time.Second, time.Minute, 5 * time.Minute, 10 * time.Minute}
 	for _, lookbackDelta := range lookbackDeltas {
 		opts.LookbackDelta = lookbackDelta
 		for _, tc := range cases {
@@ -714,7 +714,7 @@ func TestInstantQuery(t *testing.T) {
 		},
 	}
 
-	lookbackDeltas := []time.Duration{time.Minute, 5 * time.Minute, 10 * time.Minute}
+	lookbackDeltas := []time.Duration{30 * time.Second, time.Minute, 5 * time.Minute, 10 * time.Minute}
 	for _, lookbackDelta := range lookbackDeltas {
 		opts.LookbackDelta = lookbackDelta
 		for _, tc := range cases {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -440,44 +440,48 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			test, err := promql.NewTest(t, tc.load)
-			testutil.Ok(t, err)
-			defer test.Close()
+	lookbackDeltas := []time.Duration{time.Minute, 5 * time.Minute, 10 * time.Minute}
+	for _, lookbackDelta := range lookbackDeltas {
+		opts.LookbackDelta = lookbackDelta
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				test, err := promql.NewTest(t, tc.load)
+				testutil.Ok(t, err)
+				defer test.Close()
 
-			testutil.Ok(t, test.Run())
+				testutil.Ok(t, test.Run())
 
-			if tc.start.Equal(time.Time{}) {
-				tc.start = start
-			}
-			if tc.end.Equal(time.Time{}) {
-				tc.end = end
-			}
-			if tc.step == 0 {
-				tc.step = step
-			}
+				if tc.start.Equal(time.Time{}) {
+					tc.start = start
+				}
+				if tc.end.Equal(time.Time{}) {
+					tc.end = end
+				}
+				if tc.step == 0 {
+					tc.step = step
+				}
 
-			for _, disableFallback := range []bool{false, true} {
-				t.Run(fmt.Sprintf("disableFallback=%v", disableFallback), func(t *testing.T) {
-					newEngine := engine.New(engine.Opts{EngineOpts: opts, DisableFallback: disableFallback})
-					q1, err := newEngine.NewRangeQuery(test.Storage(), nil, tc.query, tc.start, tc.end, step)
-					testutil.Ok(t, err)
+				for _, disableFallback := range []bool{false, true} {
+					t.Run(fmt.Sprintf("disableFallback=%v", disableFallback), func(t *testing.T) {
+						newEngine := engine.New(engine.Opts{EngineOpts: opts, DisableFallback: disableFallback})
+						q1, err := newEngine.NewRangeQuery(test.Storage(), nil, tc.query, tc.start, tc.end, step)
+						testutil.Ok(t, err)
 
-					newResult := q1.Exec(context.Background())
-					testutil.Ok(t, newResult.Err)
+						newResult := q1.Exec(context.Background())
+						testutil.Ok(t, newResult.Err)
 
-					oldEngine := promql.NewEngine(opts)
-					q2, err := oldEngine.NewRangeQuery(test.Storage(), nil, tc.query, tc.start, tc.end, step)
-					testutil.Ok(t, err)
+						oldEngine := promql.NewEngine(opts)
+						q2, err := oldEngine.NewRangeQuery(test.Storage(), nil, tc.query, tc.start, tc.end, step)
+						testutil.Ok(t, err)
 
-					oldResult := q2.Exec(context.Background())
-					testutil.Ok(t, oldResult.Err)
+						oldResult := q2.Exec(context.Background())
+						testutil.Ok(t, oldResult.Err)
 
-					testutil.Equals(t, oldResult, newResult)
-				})
-			}
-		})
+						testutil.Equals(t, oldResult, newResult)
+					})
+				}
+			})
+		}
 	}
 }
 
@@ -710,33 +714,37 @@ func TestInstantQuery(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			test, err := promql.NewTest(t, tc.load)
-			testutil.Ok(t, err)
-			defer test.Close()
+	lookbackDeltas := []time.Duration{time.Minute, 5 * time.Minute, 10 * time.Minute}
+	for _, lookbackDelta := range lookbackDeltas {
+		opts.LookbackDelta = lookbackDelta
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				test, err := promql.NewTest(t, tc.load)
+				testutil.Ok(t, err)
+				defer test.Close()
 
-			testutil.Ok(t, test.Run())
+				testutil.Ok(t, test.Run())
 
-			for _, disableFallback := range []bool{false, true} {
-				t.Run(fmt.Sprintf("disableFallback=%v", disableFallback), func(t *testing.T) {
-					newEngine := engine.New(engine.Opts{EngineOpts: opts, DisableFallback: disableFallback})
-					q1, err := newEngine.NewInstantQuery(test.Storage(), nil, tc.query, queryTime)
-					testutil.Ok(t, err)
-					newResult := q1.Exec(context.Background())
-					testutil.Ok(t, newResult.Err)
+				for _, disableFallback := range []bool{false, true} {
+					t.Run(fmt.Sprintf("disableFallback=%v", disableFallback), func(t *testing.T) {
+						newEngine := engine.New(engine.Opts{EngineOpts: opts, DisableFallback: disableFallback})
+						q1, err := newEngine.NewInstantQuery(test.Storage(), nil, tc.query, queryTime)
+						testutil.Ok(t, err)
+						newResult := q1.Exec(context.Background())
+						testutil.Ok(t, newResult.Err)
 
-					oldEngine := promql.NewEngine(opts)
-					q2, err := oldEngine.NewInstantQuery(test.Storage(), nil, tc.query, queryTime)
-					testutil.Ok(t, err)
+						oldEngine := promql.NewEngine(opts)
+						q2, err := oldEngine.NewInstantQuery(test.Storage(), nil, tc.query, queryTime)
+						testutil.Ok(t, err)
 
-					oldResult := q2.Exec(context.Background())
-					testutil.Ok(t, oldResult.Err)
+						oldResult := q2.Exec(context.Background())
+						testutil.Ok(t, oldResult.Err)
 
-					testutil.Equals(t, oldResult, newResult)
-				})
-			}
-		})
+						testutil.Equals(t, oldResult, newResult)
+					})
+				}
+			})
+		}
 	}
 }
 

--- a/physicalplan/plan.go
+++ b/physicalplan/plan.go
@@ -70,6 +70,7 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint time.Time, ma
 				return nil, err
 			}
 
+			lookbackDelta = maxDuration(lookbackDelta, t.Range)
 			filter := scan.NewSeriesFilter(storage, mint, maxt, t.Range, lookbackDelta, vs.LabelMatchers)
 			numShards := runtime.GOMAXPROCS(0) / 2
 			if numShards < 1 {
@@ -154,4 +155,11 @@ func newScalarBinaryOperator(e *parser.BinaryExpr, storage storage.Queryable, mi
 		return binary.NewScalar(model.NewVectorPool(stepsBatch), rhs, lhs, e.Op, true)
 	}
 	return binary.NewScalar(model.NewVectorPool(stepsBatch), lhs, rhs, e.Op, false)
+}
+
+func maxDuration(a, b time.Duration) time.Duration {
+	if a.Milliseconds() >= b.Milliseconds() {
+		return a
+	}
+	return b
 }

--- a/physicalplan/plan.go
+++ b/physicalplan/plan.go
@@ -22,12 +22,12 @@ import (
 const stepsBatch = 10
 
 // New creates new physical query execution plan for a given query expression.
-func New(expr parser.Expr, storage storage.Queryable, mint, maxt time.Time, step time.Duration) (model.VectorOperator, error) {
-	return newCancellableOperator(expr, storage, mint, maxt, step)
+func New(expr parser.Expr, storage storage.Queryable, mint, maxt time.Time, step, lookbackDelta time.Duration) (model.VectorOperator, error) {
+	return newCancellableOperator(expr, storage, mint, maxt, step, lookbackDelta)
 }
 
-func newCancellableOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Time, step time.Duration) (*exchange.CancellableOperator, error) {
-	operator, err := newOperator(expr, storage, mint, maxt, step)
+func newCancellableOperator(expr parser.Expr, storage storage.Queryable, mint, maxt time.Time, step, lookbackDelta time.Duration) (*exchange.CancellableOperator, error) {
+	operator, err := newOperator(expr, storage, mint, maxt, step, lookbackDelta)
 	if err != nil {
 		return nil, err
 	}
@@ -35,13 +35,13 @@ func newCancellableOperator(expr parser.Expr, storage storage.Queryable, mint, m
 	return exchange.NewCancellable(operator), nil
 }
 
-func newOperator(expr parser.Expr, storage storage.Queryable, mint time.Time, maxt time.Time, step time.Duration) (model.VectorOperator, error) {
+func newOperator(expr parser.Expr, storage storage.Queryable, mint time.Time, maxt time.Time, step, lookbackDelta time.Duration) (model.VectorOperator, error) {
 	switch e := expr.(type) {
 	case *parser.NumberLiteral:
 		return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), mint, maxt, step, stepsBatch, e.Val, nil), nil
 
 	case *parser.VectorSelector:
-		filter := scan.NewSeriesFilter(storage, mint, maxt, 0, e.LabelMatchers)
+		filter := scan.NewSeriesFilter(storage, mint, maxt, 0, lookbackDelta, e.LabelMatchers)
 		numShards := runtime.GOMAXPROCS(0) / 2
 		if numShards < 1 {
 			numShards = 1
@@ -51,7 +51,7 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint time.Time, ma
 			operator := exchange.NewConcurrent(
 				exchange.NewCancellable(
 					scan.NewVectorSelector(
-						model.NewVectorPool(stepsBatch), filter, mint, maxt, step, stepsBatch, i, numShards)), 2)
+						model.NewVectorPool(stepsBatch), filter, mint, maxt, step, lookbackDelta, stepsBatch, i, numShards)), 2)
 			operators = append(operators, operator)
 		}
 
@@ -70,7 +70,7 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint time.Time, ma
 				return nil, err
 			}
 
-			filter := scan.NewSeriesFilter(storage, mint, maxt, t.Range, vs.LabelMatchers)
+			filter := scan.NewSeriesFilter(storage, mint, maxt, t.Range, lookbackDelta, vs.LabelMatchers)
 			numShards := runtime.GOMAXPROCS(0) / 2
 			if numShards < 1 {
 				numShards = 1
@@ -99,7 +99,7 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint time.Time, ma
 		}
 
 	case *parser.AggregateExpr:
-		next, err := newCancellableOperator(e.Expr, storage, mint, maxt, step)
+		next, err := newCancellableOperator(e.Expr, storage, mint, maxt, step, lookbackDelta)
 		if err != nil {
 			return nil, err
 		}
@@ -113,13 +113,13 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint time.Time, ma
 
 	case *parser.BinaryExpr:
 		if e.LHS.Type() == parser.ValueTypeScalar || e.RHS.Type() == parser.ValueTypeScalar {
-			return newScalarBinaryOperator(e, storage, mint, maxt, step)
+			return newScalarBinaryOperator(e, storage, mint, maxt, step, lookbackDelta)
 		}
 
-		return newVectorBinaryOperator(e, storage, mint, maxt, step)
+		return newVectorBinaryOperator(e, storage, mint, maxt, step, lookbackDelta)
 
 	case *parser.ParenExpr:
-		return newCancellableOperator(e.Expr, storage, mint, maxt, step)
+		return newCancellableOperator(e.Expr, storage, mint, maxt, step, lookbackDelta)
 
 	case *parser.StringLiteral:
 		return nil, nil
@@ -128,24 +128,24 @@ func newOperator(expr parser.Expr, storage storage.Queryable, mint time.Time, ma
 	}
 }
 
-func newVectorBinaryOperator(e *parser.BinaryExpr, storage storage.Queryable, mint time.Time, maxt time.Time, step time.Duration) (model.VectorOperator, error) {
-	leftOperator, err := newCancellableOperator(e.LHS, storage, mint, maxt, step)
+func newVectorBinaryOperator(e *parser.BinaryExpr, storage storage.Queryable, mint time.Time, maxt time.Time, step, lookbackDelta time.Duration) (model.VectorOperator, error) {
+	leftOperator, err := newCancellableOperator(e.LHS, storage, mint, maxt, step, lookbackDelta)
 	if err != nil {
 		return nil, err
 	}
-	rightOperator, err := newCancellableOperator(e.RHS, storage, mint, maxt, step)
+	rightOperator, err := newCancellableOperator(e.RHS, storage, mint, maxt, step, lookbackDelta)
 	if err != nil {
 		return nil, err
 	}
 	return binary.NewVectorOperator(model.NewVectorPool(stepsBatch), leftOperator, rightOperator, e.VectorMatching, e.Op)
 }
 
-func newScalarBinaryOperator(e *parser.BinaryExpr, storage storage.Queryable, mint time.Time, maxt time.Time, step time.Duration) (model.VectorOperator, error) {
-	lhs, err := newCancellableOperator(e.LHS, storage, mint, maxt, step)
+func newScalarBinaryOperator(e *parser.BinaryExpr, storage storage.Queryable, mint time.Time, maxt time.Time, step, lookbackDelta time.Duration) (model.VectorOperator, error) {
+	lhs, err := newCancellableOperator(e.LHS, storage, mint, maxt, step, lookbackDelta)
 	if err != nil {
 		return nil, err
 	}
-	rhs, err := newCancellableOperator(e.RHS, storage, mint, maxt, step)
+	rhs, err := newCancellableOperator(e.RHS, storage, mint, maxt, step, lookbackDelta)
 	if err != nil {
 		return nil, err
 	}

--- a/physicalplan/scan/series_selector.go
+++ b/physicalplan/scan/series_selector.go
@@ -29,11 +29,11 @@ type seriesSelector struct {
 	series []signedSeries
 }
 
-func NewSeriesFilter(storage storage.Queryable, mint time.Time, maxt time.Time, selectRange time.Duration, matchers []*labels.Matcher) *seriesSelector {
+func NewSeriesFilter(storage storage.Queryable, mint, maxt time.Time, selectRange, lookbackDelta time.Duration, matchers []*labels.Matcher) *seriesSelector {
 	return &seriesSelector{
 		storage: storage,
 
-		mint:        mint.UnixMilli() - 5*time.Minute.Milliseconds(),
+		mint:        mint.UnixMilli() - lookbackDelta.Milliseconds(),
 		maxt:        maxt.UnixMilli(),
 		selectRange: selectRange.Milliseconds(),
 		matchers:    matchers,


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

I am not sure if this covers the lookback delta usecase, but currently most of the lookbackdelta is hardcoded to 5m. This pr removes the hardcoded part and use the engine option's lookback delta value.