### PR TITLE
Remove duplicated functions in hash aggregate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,24 @@ include .bingo/Variables.mk
 FILES_TO_FMT ?= $(shell find . -path ./vendor -prune -o -name '*.go' -print)
 MDOX_VALIDATE_CONFIG ?= .mdox.validate.yaml
 
+define require_clean_work_tree
+	@git update-index -q --ignore-submodules --refresh
+
+	@if ! git diff-files --quiet --ignore-submodules --; then \
+		echo >&2 "cannot $1: you have unstaged changes."; \
+		git diff-files --name-status -r --ignore-submodules -- >&2; \
+		echo >&2 "Please commit or stash them."; \
+		exit 1; \
+	fi
+
+	@if ! git diff-index --cached --quiet HEAD --ignore-submodules --; then \
+		echo >&2 "cannot $1: your index contains uncommitted changes."; \
+		git diff-index --cached --name-status -r --ignore-submodules HEAD -- >&2; \
+		echo >&2 "Please commit or stash them."; \
+		exit 1; \
+	fi
+endef
+
 help: ## Displays help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-z0-9A-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ The current implementation creates a physical plan directly from the PromQL abst
 
 These are the latest benchmarks captured on an Apple M1 Pro processor.
 
-Note that memory usage is higher when executing a query with parallelism greater than 1. This is due to the fact that the engine is able to execute multiple operations at once (e.g. decode chunks from multiple series at the same time), which requires using independent buffers for each parallel operation. 
+Note that memory usage is higher when executing a query with parallelism greater than 1. This is due to the fact that the engine is able to execute multiple operations at once (e.g. decode chunks from multiple series at the same time), which requires using independent buffers for each parallel operation.
 
 Single core benchmarks
+
 ```markdown
 name                                                old time/op    new time/op    delta
 RangeQuery/vector_selector                            28.1ms ± 2%    34.2ms ± 4%  +21.80%  (p=0.000 n=9+10)
@@ -123,6 +124,7 @@ RangeQuery/binary_operation_with_vector_and_scalar     84.4k ± 0%     86.6k ± 
 ```
 
 Multi-core (8 core) benchmarks
+
 ```markdown
 name                                                  old time/op    new time/op    delta
 RangeQuery/vector_selector-8                            27.3ms ± 3%    13.7ms ± 3%  -49.94%  (p=0.000 n=10+10)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ At the beginning of a PromQL query execution, the query engine computes a physic
 Operators are assembled in a tree-like structure with every operator calling `Next()` on its dependants until there is no more data to be returned. The result of the `Next()` function is a *column vector* (also called a *step vector*) with elements in the vector representing samples with the same timestamp from different time series.
 
 <p align="center">
-  <img src="./assets/design.png" />
+  <img src="./assets/design.png"/>
 </p>
 
 This model allows for samples from individual time series to flow one execution step at a time from the left-most operators to the one at the very right. Since most PromQL expressions are aggregations, samples are reduced in number as they are pulled by the operators on the right. Because of this, samples from original timeseries can be decoded and kept in memory in batches instead of being fully expanded.
@@ -40,7 +40,7 @@ In addition to operators that have a one-to-one mapping with PromQL constructs, 
 Since operators are independent and rely on a common interface for pulling data, they can be run in parallel to each other. As soon as one operator has processed data from an evaluation step, it can pass the result onward so that its upstream can immediately start working on it.
 
 <p align="center">
-  <img src="./assets/promql-pipeline.png" />
+  <img src="./assets/promql-pipeline.png"/>
 </p>
 
 ### Intra-operator parallelism
@@ -48,7 +48,7 @@ Since operators are independent and rely on a common interface for pulling data,
 Parallelism can also be added within individual operators using a parallel coalesce exchange operator. Such exchange operators are indistinguishable from regular operators to their upstreams since they respect the same `Next()` interface.
 
 <p align="center">
-  <img src="./assets/parallel-coalesce.png" />
+  <img src="./assets/parallel-coalesce.png"/>
 </p>
 
 ### Memory management

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
 package engine_test
 
 import (

--- a/physicalplan/aggregate/vector_table.go
+++ b/physicalplan/aggregate/vector_table.go
@@ -5,16 +5,14 @@ package aggregate
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/efficientgo/core/errors"
 
-	"github.com/thanos-community/promql-engine/physicalplan/model"
-	"github.com/thanos-community/promql-engine/physicalplan/parse"
-	"github.com/thanos-community/promql-engine/physicalplan/scan"
-
 	"github.com/prometheus/prometheus/promql/parser"
 	"gonum.org/v1/gonum/floats"
+
+	"github.com/thanos-community/promql-engine/physicalplan/model"
+	"github.com/thanos-community/promql-engine/physicalplan/parse"
 )
 
 type vectorAccumulator func([]float64) float64
@@ -87,32 +85,6 @@ func newVectorAccumulator(expr parser.ItemType) (vectorAccumulator, error) {
 	case "avg":
 		return func(in []float64) float64 {
 			return floats.Sum(in) / float64(len(in))
-		}, nil
-	case "stddev":
-		return func(in []float64) float64 {
-			var count float64
-			var mean, cMean float64
-			var aux, cAux float64
-			for _, v := range in {
-				count++
-				delta := v - (mean + cMean)
-				mean, cMean = scan.KahanSumInc(delta/count, mean, cMean)
-				aux, cAux = scan.KahanSumInc(delta*(v-(mean+cMean)), aux, cAux)
-			}
-			return math.Sqrt((aux + cAux) / count)
-		}, nil
-	case "stdvar":
-		return func(in []float64) float64 {
-			var count float64
-			var mean, cMean float64
-			var aux, cAux float64
-			for _, v := range in {
-				count++
-				delta := v - (mean + cMean)
-				mean, cMean = scan.KahanSumInc(delta/count, mean, cMean)
-				aux, cAux = scan.KahanSumInc(delta*(v-(mean+cMean)), aux, cAux)
-			}
-			return (aux + cAux) / count
 		}, nil
 	case "group":
 		return func(in []float64) float64 {

--- a/physicalplan/binary/index.go
+++ b/physicalplan/binary/index.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
 package binary
 
 type outputIndex interface {

--- a/physicalplan/exchange/cancellable.go
+++ b/physicalplan/exchange/cancellable.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
 package exchange
 
 import (

--- a/physicalplan/parse/errors.go
+++ b/physicalplan/parse/errors.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
 package parse
 
 import "github.com/efficientgo/core/errors"


### PR DESCRIPTION
We currently have duplicated code for vector and scalar tables in the hash aggregate function.

This commit removes the duplicates by instantiating scalar tables whenever we don't have vectorized support for operations used in the aggregate operator.