### PR TITLE
Resolve panics in instant queries

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -597,6 +597,14 @@ func TestInstantQuery(t *testing.T) {
 			query: "sum(rate(http_requests_total[1m]))",
 		},
 		{
+			name: "sum rate with single sample series",
+			load: `load 30s
+					http_requests_total{pod="nginx-1"} 1+1x4
+					http_requests_total{pod="nginx-2"} 1+2x4
+					http_requests_total{pod="nginx-3"} 0`,
+			query: "sum by (pod) (rate(http_requests_total[1m]))",
+		},
+		{
 			name: "sum rate with stale series",
 			load: `load 30s
 					http_requests_total{pod="nginx-1"} 1+1x4

--- a/engine/instant_query.go
+++ b/engine/instant_query.go
@@ -82,17 +82,20 @@ func (q *instantQuery) Exec(ctx context.Context) *promql.Result {
 		result = promql.Matrix(series)
 	case parser.ValueTypeVector:
 		// Convert matrix with one value per series into vector.
-		vector := make(promql.Vector, len(resultSeries))
+		vector := make(promql.Vector, 0, len(resultSeries))
 		for i := range series {
+			if len(series[i].Points) == 0 {
+				continue
+			}
 			// Point might have a different timestamp, force it to the evaluation
 			// timestamp as that is when we ran the evaluation.
-			vector[i] = promql.Sample{
+			vector = append(vector, promql.Sample{
 				Metric: series[i].Metric,
 				Point: promql.Point{
 					V: series[i].Points[0].V,
 					T: q.ts.UnixMilli(),
 				},
-			}
+			})
 		}
 		result = vector
 	case parser.ValueTypeScalar:


### PR DESCRIPTION
The series call in instant queries can return more series than the
query can produce. This is because operations like rate will not
produce an output when a series has only one sample in the evaluation
period. The case cannot be detected during the Series call because
it requires decoding chunks, a process that happens only during Next
calls.  This can lead to the series being returned by the Series call,
but never having samples produced by a Next call.

This commit resolves the issue by explicitly checking whether a
series has produced a sample before trying to access the sample.
An illustrative test case is also added in the commit.
