### PR TITLE
Improve vector selector performance

### DIFF
--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/prometheus/prometheus/promql"
+
 	"github.com/thanos-community/promql-engine/engine"
 )
 

--- a/physicalplan/scan/vector_selector.go
+++ b/physicalplan/scan/vector_selector.go
@@ -9,18 +9,71 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+
 	"github.com/thanos-community/promql-engine/physicalplan/model"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
-
-	"github.com/prometheus/prometheus/storage"
 )
 
 type vectorScanner struct {
 	labels    labels.Labels
 	signature uint64
-	samples   *storage.MemoizedSeriesIterator
+	samples   chunkenc.Iterator
+
+	// Fields used to track the previous seen sample.
+	// Used for supporting lookback delta.
+	pastFirstIteration bool
+	hasPrev            bool
+	prevTime           int64
+	prevValue          float64
+}
+
+func (it *vectorScanner) At() (int64, float64) { return it.samples.At() }
+
+func (it *vectorScanner) Seek(ts int64) bool {
+	for {
+		if it.pastFirstIteration {
+			t, v := it.samples.At()
+			it.prevTime = t
+			it.prevValue = v
+			it.hasPrev = true
+		}
+
+		if it.samples.Next() {
+			it.pastFirstIteration = true
+			t, _ := it.samples.At()
+			if t >= ts {
+				return true
+			}
+		} else {
+			return false
+		}
+	}
+}
+
+// TODO(fpetkovski): Add error handling and max samples limit.
+func (it *vectorScanner) selectPoint(ts, lookbackDelta int64) (int64, float64, bool) {
+	refTime := ts
+	var t int64
+	var v float64
+
+	ok := it.Seek(refTime)
+	if ok {
+		t, v = it.At()
+	}
+
+	if !ok || t > refTime {
+		t, v, ok = it.prevTime, it.prevValue, it.hasPrev
+		if !ok || t < refTime-lookbackDelta {
+			return 0, 0, false
+		}
+	}
+	if value.IsStaleNaN(v) {
+		return 0, 0, false
+	}
+	return t, v, true
 }
 
 type vectorSelector struct {
@@ -95,7 +148,7 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 	ts := o.currentStep
 	for i := 0; i < len(o.scanners); i++ {
 		var (
-			series   = o.scanners[i]
+			series   = &o.scanners[i]
 			seriesTs = ts
 		)
 
@@ -103,7 +156,7 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 			if len(vectors) <= currStep {
 				vectors = append(vectors, o.vectorPool.GetStepVector(seriesTs))
 			}
-			_, v, ok := selectPoint(series.samples, seriesTs, o.lookbackDelta)
+			_, v, ok := series.selectPoint(seriesTs, o.lookbackDelta)
 			if ok {
 				vectors[currStep].SampleIDs = append(vectors[currStep].SampleIDs, series.signature)
 				vectors[currStep].Samples = append(vectors[currStep].Samples, v)
@@ -131,34 +184,11 @@ func (o *vectorSelector) loadSeries(ctx context.Context) error {
 			o.scanners[i] = vectorScanner{
 				labels:    s.Labels(),
 				signature: s.signature,
-				samples:   storage.NewMemoizedIterator(s.Iterator(), o.lookbackDelta),
+				samples:   s.Iterator(),
 			}
 			o.series[i] = s.Labels()
 		}
 		o.vectorPool.SetStepSize(len(series))
 	})
 	return err
-}
-
-// TODO(fpetkovski): Add error handling and max samples limit.
-func selectPoint(it *storage.MemoizedSeriesIterator, ts, lookbackDelta int64) (int64, float64, bool) {
-	refTime := ts
-	var t int64
-	var v float64
-
-	ok := it.Seek(refTime)
-	if ok {
-		t, v = it.At()
-	}
-
-	if !ok || t > refTime {
-		t, v, ok = it.PeekPrev()
-		if !ok || t < refTime-lookbackDelta {
-			return 0, 0, false
-		}
-	}
-	if value.IsStaleNaN(v) {
-		return 0, 0, false
-	}
-	return t, v, true
 }

--- a/physicalplan/unary/unary.go
+++ b/physicalplan/unary/unary.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
 package unary
 
 import (


### PR DESCRIPTION
We currently rely on using the MemoizedSeriesIterator from Prometheus which can keep the last seen sample for each series. This iterator seems to be doing many more things that are not really relevant for decoding chunks.

This commit reimplements the logic into the vectorScanner directly and manages to achieve a slight performance improvement by doing that.

Benchmarks show a small, but still significant improvement. Operations involving rate are as before, which is also expected.

```
name                                                old time/op    new time/op    delta
RangeQuery/vector_selector                            33.7ms ± 1%    33.4ms ± 4%    ~     (p=0.604 n=9+10)
RangeQuery/sum                                        29.9ms ±12%    27.4ms ± 6%  -8.30%  (p=0.001 n=9+10)
RangeQuery/sum_by_pod                                 36.8ms ± 1%    35.6ms ± 2%  -3.06%  (p=0.000 n=9+10)
RangeQuery/rate                                       58.4ms ± 3%    57.9ms ± 1%    ~     (p=0.218 n=10+10)
RangeQuery/sum_rate                                   51.8ms ± 1%    51.5ms ± 1%    ~     (p=0.063 n=10+10)
RangeQuery/sum_by_rate                                61.4ms ± 4%    61.7ms ± 5%    ~     (p=0.905 n=9+10)
RangeQuery/binary_operation_with_one_to_one           2.39ms ± 2%    2.34ms ± 3%  -2.01%  (p=0.011 n=8+9)
RangeQuery/binary_operation_with_many_to_one          50.4ms ± 1%    48.7ms ± 2%  -3.32%  (p=0.000 n=10+9)
RangeQuery/binary_operation_with_vector_and_scalar    37.7ms ± 2%    35.9ms ± 2%  -4.61%  (p=0.000 n=9+9)

name                                                old alloc/op   new alloc/op   delta
RangeQuery/vector_selector                            25.7MB ± 0%    25.6MB ± 0%  -0.36%  (p=0.000 n=10+10)
RangeQuery/sum                                        6.93MB ± 0%    6.84MB ± 0%  -1.35%  (p=0.000 n=10+9)
RangeQuery/sum_by_pod                                 16.0MB ± 0%    15.9MB ± 0%  -0.58%  (p=0.000 n=10+10)
RangeQuery/rate                                       28.2MB ± 0%    28.2MB ± 0%    ~     (p=0.324 n=10+10)
RangeQuery/sum_rate                                   9.38MB ± 0%    9.38MB ± 0%  -0.00%  (p=0.002 n=10+8)
RangeQuery/sum_by_rate                                18.4MB ± 0%    18.4MB ± 0%    ~     (p=0.143 n=10+10)
RangeQuery/binary_operation_with_one_to_one           2.83MB ± 0%    2.80MB ± 0%  -1.11%  (p=0.000 n=10+9)
RangeQuery/binary_operation_with_many_to_one          31.4MB ± 0%    31.3MB ± 0%  -0.40%  (p=0.000 n=10+10)
RangeQuery/binary_operation_with_vector_and_scalar    28.6MB ± 0%    28.5MB ± 0%  -0.33%  (p=0.000 n=10+9)

name                                                old allocs/op  new allocs/op  delta
RangeQuery/vector_selector                             76.7k ± 0%     73.7k ± 0%  -3.91%  (p=0.000 n=10+10)
RangeQuery/sum                                         71.4k ± 0%     68.4k ± 0%  -4.20%  (p=0.000 n=10+10)
RangeQuery/sum_by_pod                                   156k ± 0%      153k ± 0%  -1.92%  (p=0.000 n=10+10)
RangeQuery/rate                                         104k ± 0%      104k ± 0%    ~     (p=0.358 n=10+10)
RangeQuery/sum_rate                                    98.4k ± 0%     98.4k ± 0%  -0.00%  (p=0.013 n=10+8)
RangeQuery/sum_by_rate                                  183k ± 0%      183k ± 0%    ~     (p=0.276 n=10+10)
RangeQuery/binary_operation_with_one_to_one            20.7k ± 0%     19.7k ± 0%  -4.84%  (p=0.000 n=8+10)
RangeQuery/binary_operation_with_many_to_one            126k ± 0%      122k ± 0%  -3.17%  (p=0.000 n=9+10)
RangeQuery/binary_operation_with_vector_and_scalar     86.6k ± 0%     83.6k ± 0%  -3.46%  (p=0.000 n=10+7)
```