### PR TITLE
Added explain methods. Explain plan when opts.DebugWriter != nil.

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -5,14 +5,15 @@ package engine
 
 import (
 	"fmt"
+	"io"
 	"runtime"
 	"time"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-
 	"github.com/thanos-community/promql-engine/physicalplan"
+	"github.com/thanos-community/promql-engine/physicalplan/model"
 	"github.com/thanos-community/promql-engine/physicalplan/parse"
 
 	"github.com/prometheus/prometheus/promql"
@@ -22,8 +23,8 @@ import (
 )
 
 type engine struct {
-	logger log.Logger
-
+	logger        log.Logger
+	debugWriter   io.Writer
 	lookbackDelta time.Duration
 }
 
@@ -33,6 +34,11 @@ type Opts struct {
 	// DisableFallback enables mode where engine returns error if some expression of feature is not yet implemented
 	// in the new engine, instead of falling back to prometheus engine.
 	DisableFallback bool
+
+	// DebugWriter specifies output for debug (multi-line) information meant for humans debugging the engine.
+	// If nil, nothing will be printed.
+	// NOTE: Users will not check the errors, debug writing is best effort.
+	DebugWriter io.Writer
 }
 
 func New(opts Opts) v1.QueryEngine {
@@ -41,14 +47,13 @@ func New(opts Opts) v1.QueryEngine {
 	}
 	if opts.LookbackDelta == 0 {
 		opts.LookbackDelta = 5 * time.Minute
-		if l := opts.Logger; l != nil {
-			level.Debug(l).Log("msg", "lookback delta is zero, setting to default value", "value", 5*time.Minute)
-		}
+		level.Debug(opts.Logger).Log("msg", "lookback delta is zero, setting to default value", "value", 5*time.Minute)
 	}
 
 	core := &engine{
-		lookbackDelta: opts.LookbackDelta,
+		debugWriter:   opts.DebugWriter,
 		logger:        opts.Logger,
+		lookbackDelta: opts.LookbackDelta,
 	}
 	if opts.DisableFallback {
 		return core
@@ -98,7 +103,7 @@ func triggerFallback(err error) bool {
 
 var errNotImplemented = errors.New("not implemented")
 
-func (e *engine) NewInstantQuery(q storage.Queryable, opts *promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {
+func (e *engine) NewInstantQuery(q storage.Queryable, _ *promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {
 	expr, err := parser.ParseExpr(qs)
 	if err != nil {
 		return nil, err
@@ -109,10 +114,14 @@ func (e *engine) NewInstantQuery(q storage.Queryable, opts *promql.QueryOpts, qs
 		return nil, err
 	}
 
+	if e.debugWriter != nil {
+		explain(e.debugWriter, plan, "", "")
+	}
+
 	return newInstantQuery(e.logger, plan, expr, ts), nil
 }
 
-func (e *engine) NewRangeQuery(q storage.Queryable, opts *promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error) {
+func (e *engine) NewRangeQuery(q storage.Queryable, _ *promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error) {
 	expr, err := parser.ParseExpr(qs)
 	if err != nil {
 		return nil, err
@@ -126,6 +135,10 @@ func (e *engine) NewRangeQuery(q storage.Queryable, opts *promql.QueryOpts, qs s
 	plan, err := physicalplan.New(expr, q, start, end, interval, e.lookbackDelta)
 	if err != nil {
 		return nil, err
+	}
+
+	if e.debugWriter != nil {
+		explain(e.debugWriter, plan, "", "")
 	}
 
 	return newRangeQuery(expr, e.logger, plan), nil
@@ -145,5 +158,30 @@ func recoverEngine(logger log.Logger, expr parser.Expr, errp *error) {
 
 		level.Error(logger).Log("msg", "runtime panic in engine", "expr", expr.String(), "err", e, "stacktrace", string(buf))
 		*errp = fmt.Errorf("unexpected error: %w", err)
+	}
+}
+
+func explain(w io.Writer, o model.VectorOperator, indent, indentNext string) {
+	me, next := o.Explain()
+	_, _ = w.Write([]byte(indent))
+	_, _ = w.Write([]byte(me))
+	if len(next) == 0 {
+		_, _ = w.Write([]byte("\n"))
+		return
+	}
+
+	if me == "[*CancellableOperator]" {
+		_, _ = w.Write([]byte(": "))
+		explain(w, next[0], "", indentNext)
+		return
+	}
+	_, _ = w.Write([]byte(":\n"))
+
+	for i, n := range next {
+		if i == len(next)-1 {
+			explain(w, n, indentNext+"└──", indentNext+"   ")
+		} else {
+			explain(w, n, indentNext+"├──", indentNext+"│  ")
+		}
 	}
 }

--- a/engine/range_query.go
+++ b/engine/range_query.go
@@ -40,6 +40,7 @@ func (q *rangeQuery) Exec(ctx context.Context) (ret *promql.Result) {
 	ctx, cancel := context.WithCancel(ctx)
 	q.cancel = cancel
 
+	// TODO(bwplotka): This feels weird. Why we have public Close method in the first place if we don't let user to use it.
 	defer q.Close()
 
 	resultSeries, err := q.plan.Series(ctx)

--- a/physicalplan/aggregate/hashaggregate.go
+++ b/physicalplan/aggregate/hashaggregate.go
@@ -5,6 +5,7 @@ package aggregate
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/efficientgo/core/errors"
@@ -61,6 +62,13 @@ func NewHashAggregate(
 	a.workers = worker.NewGroup(stepsBatch, a.workerTask)
 
 	return a, nil
+}
+
+func (a *aggregate) Explain() (me string, next []model.VectorOperator) {
+	if a.by {
+		return fmt.Sprintf("[*aggregate] %v by (%v)", a.aggregation.String(), a.labels), []model.VectorOperator{a.next}
+	}
+	return fmt.Sprintf("[*aggregate] %v without (%v)", a.aggregation.String(), a.labels), []model.VectorOperator{a.next}
 }
 
 func (a *aggregate) Series(ctx context.Context) ([]labels.Labels, error) {

--- a/physicalplan/exchange/cancellable.go
+++ b/physicalplan/exchange/cancellable.go
@@ -11,12 +11,19 @@ import (
 	"github.com/thanos-community/promql-engine/physicalplan/model"
 )
 
+// TODO(bwplotka): Consider removing this and ensuring all operators check for context. It creates
+// unnecessary cognitive and computation load, only to avoid one "if ctx.Err() != nil" in each operator.
+// It is also inconsistently added (sometimes missing).
 type CancellableOperator struct {
 	next model.VectorOperator
 }
 
 func NewCancellable(next model.VectorOperator) *CancellableOperator {
 	return &CancellableOperator{next: next}
+}
+
+func (c *CancellableOperator) Explain() (string, []model.VectorOperator) {
+	return "[*CancellableOperator]", []model.VectorOperator{c.next}
 }
 
 func (c *CancellableOperator) Next(ctx context.Context) ([]model.StepVector, error) {

--- a/physicalplan/exchange/coalesce.go
+++ b/physicalplan/exchange/coalesce.go
@@ -39,6 +39,10 @@ func NewCoalesce(pool *model.VectorPool, operators ...model.VectorOperator) mode
 	}
 }
 
+func (c *coalesceOperator) Explain() (me string, next []model.VectorOperator) {
+	return "[*coalesceOperator]", c.operators
+}
+
 func (c *coalesceOperator) GetPool() *model.VectorPool {
 	return c.pool
 }

--- a/physicalplan/model/operator.go
+++ b/physicalplan/model/operator.go
@@ -9,8 +9,17 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
+// VectorOperator performs operations on series in step by step fashion.
 type VectorOperator interface {
+	// Next yields stream of samples representing series (vector of multiple series) per one or more steps.
 	Next(ctx context.Context) ([]StepVector, error)
+
+	// Series returns all series that we will see in all Next results.
 	Series(ctx context.Context) ([]labels.Labels, error)
+
+	// GetPool returns pool of vectors that can be shared across operators.
 	GetPool() *VectorPool
+
+	// Explain returns human-readable explanation of the current operator and optional nested operators.
+	Explain() (me string, next []VectorOperator)
 }

--- a/physicalplan/scan/function.go
+++ b/physicalplan/scan/function.go
@@ -18,6 +18,7 @@ import (
 
 var InvalidSample = promql.Sample{Point: promql.Point{T: -1, V: 0}}
 
+// FunctionCall represents functions as defined in https://prometheus.io/docs/prometheus/latest/querying/functions/
 type FunctionCall func(labels labels.Labels, points []promql.Point, stepTime time.Time, selectRange time.Duration) promql.Sample
 
 var Funcs = map[string]FunctionCall{

--- a/physicalplan/scan/matrix_selector.go
+++ b/physicalplan/scan/matrix_selector.go
@@ -5,6 +5,7 @@ package scan
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sort"
 	"sync"
@@ -29,7 +30,7 @@ type matrixScanner struct {
 type matrixSelector struct {
 	funcExpr *parser.Call
 	call     FunctionCall
-	selector *seriesSelector
+	storage  *seriesSelector
 	scanners []matrixScanner
 	series   []labels.Labels
 	once     sync.Once
@@ -47,6 +48,7 @@ type matrixSelector struct {
 	numShards int
 }
 
+// NewMatrixSelector creates operator which selects vector of series over time.
 func NewMatrixSelector(
 	pool *model.VectorPool,
 	selector *seriesSelector,
@@ -59,7 +61,7 @@ func NewMatrixSelector(
 ) model.VectorOperator {
 	// TODO(fpetkovski): Add offset parameter.
 	return &matrixSelector{
-		selector:   selector,
+		storage:    selector,
 		call:       call,
 		funcExpr:   funcExpr,
 		vectorPool: pool,
@@ -75,6 +77,14 @@ func NewMatrixSelector(
 		shard:     shard,
 		numShards: numShard,
 	}
+}
+
+func (o *matrixSelector) Explain() (me string, next []model.VectorOperator) {
+	r := time.Duration(o.selectRange) * time.Millisecond
+	if o.call != nil {
+		return fmt.Sprintf("[*matrixSelector] %v({%v}[%s] %v mod %v)", o.funcExpr.Func.Name, o.storage.matchers, r, o.shard, o.numShards), nil
+	}
+	return fmt.Sprintf("[*matrixSelector] {%v}[%s] %v mod %v", o.storage.matchers, r, o.shard, o.numShards), nil
 }
 
 func (o *matrixSelector) Series(ctx context.Context) ([]labels.Labels, error) {
@@ -150,7 +160,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 func (o *matrixSelector) loadSeries(ctx context.Context) error {
 	var err error
 	o.once.Do(func() {
-		series, loadErr := o.selector.getSeries(ctx, o.shard, o.numShards)
+		series, loadErr := o.storage.getSeries(ctx, o.shard, o.numShards)
 		if loadErr != nil {
 			err = loadErr
 			return


### PR DESCRIPTION
Plus a small cleanups.

<details closed>
<summary>Example outputs for some more interesting cases from tests</summary>
<br>

```
*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] stddev_over_time({[__name__="http_requests_total"]}[30s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] stddev_over_time({[__name__="http_requests_total"]}[30s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] stddev_over_time({[__name__="http_requests_total"]}[30s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] stddev_over_time({[__name__="http_requests_total"]}[30s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] stddev_over_time({[__name__="http_requests_total"]}[30s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] stddev_over_time({[__name__="http_requests_total"]}[30s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/stdvar_over_time
=== RUN   TestQueriesAgainstOldEngine/stdvar_over_time/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] stdvar_over_time({[__name__="http_requests_total"]}[30s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] stdvar_over_time({[__name__="http_requests_total"]}[30s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] stdvar_over_time({[__name__="http_requests_total"]}[30s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] stdvar_over_time({[__name__="http_requests_total"]}[30s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] stdvar_over_time({[__name__="http_requests_total"]}[30s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] stdvar_over_time({[__name__="http_requests_total"]}[30s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/changes
=== RUN   TestQueriesAgainstOldEngine/changes/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] changes({[__name__="http_requests_total"]}[30s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] changes({[__name__="http_requests_total"]}[30s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] changes({[__name__="http_requests_total"]}[30s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] changes({[__name__="http_requests_total"]}[30s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] changes({[__name__="http_requests_total"]}[30s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] changes({[__name__="http_requests_total"]}[30s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/deriv
=== RUN   TestQueriesAgainstOldEngine/deriv/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] deriv({[__name__="http_requests_total"]}[30s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] deriv({[__name__="http_requests_total"]}[30s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] deriv({[__name__="http_requests_total"]}[30s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] deriv({[__name__="http_requests_total"]}[30s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] deriv({[__name__="http_requests_total"]}[30s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] deriv({[__name__="http_requests_total"]}[30s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/sum
=== RUN   TestQueriesAgainstOldEngine/sum/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] sum by ([]):
   └──[*CancellableOperator]: [*coalesceOperator]:
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
      └──[*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/sum_over_time
=== RUN   TestQueriesAgainstOldEngine/sum_over_time/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] sum_over_time({[__name__="http_requests_total"]}[30s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] sum_over_time({[__name__="http_requests_total"]}[30s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] sum_over_time({[__name__="http_requests_total"]}[30s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] sum_over_time({[__name__="http_requests_total"]}[30s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] sum_over_time({[__name__="http_requests_total"]}[30s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] sum_over_time({[__name__="http_requests_total"]}[30s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/count
=== RUN   TestQueriesAgainstOldEngine/count/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] count by ([]):
   └──[*CancellableOperator]: [*coalesceOperator]:
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
      └──[*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/count_over_time
=== RUN   TestQueriesAgainstOldEngine/count_over_time/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] count_over_time({[__name__="http_requests_total"]}[30s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] count_over_time({[__name__="http_requests_total"]}[30s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] count_over_time({[__name__="http_requests_total"]}[30s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] count_over_time({[__name__="http_requests_total"]}[30s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] count_over_time({[__name__="http_requests_total"]}[30s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] count_over_time({[__name__="http_requests_total"]}[30s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/average
=== RUN   TestQueriesAgainstOldEngine/average/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] avg by ([]):
   └──[*CancellableOperator]: [*coalesceOperator]:
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
      └──[*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/avg_over_time
=== RUN   TestQueriesAgainstOldEngine/avg_over_time/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] avg_over_time({[__name__="http_requests_total"]}[30s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] avg_over_time({[__name__="http_requests_total"]}[30s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] avg_over_time({[__name__="http_requests_total"]}[30s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] avg_over_time({[__name__="http_requests_total"]}[30s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] avg_over_time({[__name__="http_requests_total"]}[30s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] avg_over_time({[__name__="http_requests_total"]}[30s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/max
=== RUN   TestQueriesAgainstOldEngine/max/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] max by ([]):
   └──[*CancellableOperator]: [*coalesceOperator]:
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
      └──[*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/max_with_only_1_sample
=== RUN   TestQueriesAgainstOldEngine/max_with_only_1_sample/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] max by ([pod]):
   └──[*CancellableOperator]: [*coalesceOperator]:
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
      └──[*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/max_over_time
=== RUN   TestQueriesAgainstOldEngine/max_over_time/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] max_over_time({[__name__="http_requests_total"]}[30s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] max_over_time({[__name__="http_requests_total"]}[30s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] max_over_time({[__name__="http_requests_total"]}[30s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] max_over_time({[__name__="http_requests_total"]}[30s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] max_over_time({[__name__="http_requests_total"]}[30s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] max_over_time({[__name__="http_requests_total"]}[30s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/min
=== RUN   TestQueriesAgainstOldEngine/min/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] min by ([]):
   └──[*CancellableOperator]: [*coalesceOperator]:
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
      └──[*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/min_with_only_1_sample
=== RUN   TestQueriesAgainstOldEngine/min_with_only_1_sample/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] min by ([pod]):
   └──[*CancellableOperator]: [*coalesceOperator]:
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
      └──[*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/min_over_time
=== RUN   TestQueriesAgainstOldEngine/min_over_time/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] min_over_time({[__name__="http_requests_total"]}[30s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] min_over_time({[__name__="http_requests_total"]}[30s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] min_over_time({[__name__="http_requests_total"]}[30s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] min_over_time({[__name__="http_requests_total"]}[30s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] min_over_time({[__name__="http_requests_total"]}[30s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] min_over_time({[__name__="http_requests_total"]}[30s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/count_over_time#01
=== RUN   TestQueriesAgainstOldEngine/count_over_time#01/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] count_over_time({[__name__="http_requests_total"]}[30s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] count_over_time({[__name__="http_requests_total"]}[30s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] count_over_time({[__name__="http_requests_total"]}[30s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] count_over_time({[__name__="http_requests_total"]}[30s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] count_over_time({[__name__="http_requests_total"]}[30s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] count_over_time({[__name__="http_requests_total"]}[30s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/sum_by_pod
=== RUN   TestQueriesAgainstOldEngine/sum_by_pod/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] sum by ([pod]):
   └──[*CancellableOperator]: [*coalesceOperator]:
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
      └──[*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/query_in_the_future
=== RUN   TestQueriesAgainstOldEngine/query_in_the_future/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] sum by ([pod]):
   └──[*CancellableOperator]: [*coalesceOperator]:
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
      └──[*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/rate
=== RUN   TestQueriesAgainstOldEngine/rate/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/sum_rate
=== RUN   TestQueriesAgainstOldEngine/sum_rate/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] sum by ([]):
   └──[*CancellableOperator]: [*coalesceOperator]:
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 0 mod 6)
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 1 mod 6)
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 2 mod 6)
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 3 mod 6)
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 4 mod 6)
      └──[*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/sum_rate_with_stale_series
=== RUN   TestQueriesAgainstOldEngine/sum_rate_with_stale_series/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] sum by ([]):
   └──[*CancellableOperator]: [*coalesceOperator]:
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 0 mod 6)
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 1 mod 6)
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 2 mod 6)
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 3 mod 6)
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 4 mod 6)
      └──[*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/delta
=== RUN   TestQueriesAgainstOldEngine/delta/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] delta({[__name__="http_requests_total"]}[1m0s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] delta({[__name__="http_requests_total"]}[1m0s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] delta({[__name__="http_requests_total"]}[1m0s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] delta({[__name__="http_requests_total"]}[1m0s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] delta({[__name__="http_requests_total"]}[1m0s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] delta({[__name__="http_requests_total"]}[1m0s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/increase
=== RUN   TestQueriesAgainstOldEngine/increase/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] increase({[__name__="http_requests_total"]}[1m0s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] increase({[__name__="http_requests_total"]}[1m0s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] increase({[__name__="http_requests_total"]}[1m0s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] increase({[__name__="http_requests_total"]}[1m0s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] increase({[__name__="http_requests_total"]}[1m0s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] increase({[__name__="http_requests_total"]}[1m0s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/irate
=== RUN   TestQueriesAgainstOldEngine/irate/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] irate({[__name__="http_requests_total"]}[1m0s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] irate({[__name__="http_requests_total"]}[1m0s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] irate({[__name__="http_requests_total"]}[1m0s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] irate({[__name__="http_requests_total"]}[1m0s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] irate({[__name__="http_requests_total"]}[1m0s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] irate({[__name__="http_requests_total"]}[1m0s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/idelta
=== RUN   TestQueriesAgainstOldEngine/idelta/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] idelta({[__name__="http_requests_total"]}[1m0s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] idelta({[__name__="http_requests_total"]}[1m0s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] idelta({[__name__="http_requests_total"]}[1m0s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] idelta({[__name__="http_requests_total"]}[1m0s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] idelta({[__name__="http_requests_total"]}[1m0s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] idelta({[__name__="http_requests_total"]}[1m0s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/number_literal
=== RUN   TestQueriesAgainstOldEngine/number_literal/disableFallback=true
[*CancellableOperator]: [*numberLiteralSelector] 34
=== RUN   TestQueriesAgainstOldEngine/vector
=== RUN   TestQueriesAgainstOldEngine/vector/disableFallback=true
[*CancellableOperator]: [*CancellableOperator]: [*numberLiteralSelector] vector(24)
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_one-to-one_matching
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_one-to-one_matching/disableFallback=true
[*CancellableOperator]: [*vectorOperator] + one-to-one ignoring false group []:
├──[*CancellableOperator]: [*coalesceOperator]:
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[code="500" __name__="foo"]} 0 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[code="500" __name__="foo"]} 1 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[code="500" __name__="foo"]} 2 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[code="500" __name__="foo"]} 3 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[code="500" __name__="foo"]} 4 mod 6
│  └──[*concurrencyOperator(buff=2)]:
│     └──[*CancellableOperator]: [*vectorSelector] {[code="500" __name__="foo"]} 5 mod 6
└──[*CancellableOperator]: [*coalesceOperator]:
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 0 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 1 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 2 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 3 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 4 mod 6
   └──[*concurrencyOperator(buff=2)]:
      └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_group_left
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_group_left/disableFallback=true
[*CancellableOperator]: [*vectorOperator] * many-to-one ignoring false group []:
├──[*CancellableOperator]: [*coalesceOperator]:
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 0 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 1 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 2 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 3 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 4 mod 6
│  └──[*concurrencyOperator(buff=2)]:
│     └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 5 mod 6
└──[*CancellableOperator]: [*coalesceOperator]:
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 0 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 1 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 2 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 3 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 4 mod 6
   └──[*concurrencyOperator(buff=2)]:
      └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_group_right
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_group_right/disableFallback=true
[*CancellableOperator]: [*vectorOperator] * one-to-many ignoring false group []:
├──[*CancellableOperator]: [*coalesceOperator]:
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 0 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 1 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 2 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 3 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 4 mod 6
│  └──[*concurrencyOperator(buff=2)]:
│     └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 5 mod 6
└──[*CancellableOperator]: [*coalesceOperator]:
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 0 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 1 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 2 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 3 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 4 mod 6
   └──[*concurrencyOperator(buff=2)]:
      └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_group_left_and_included_labels
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_group_left_and_included_labels/disableFallback=true
[*CancellableOperator]: [*vectorOperator] * many-to-one ignoring false group [path]:
├──[*CancellableOperator]: [*coalesceOperator]:
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 0 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 1 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 2 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 3 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 4 mod 6
│  └──[*concurrencyOperator(buff=2)]:
│     └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 5 mod 6
└──[*CancellableOperator]: [*coalesceOperator]:
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 0 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 1 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 2 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 3 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 4 mod 6
   └──[*concurrencyOperator(buff=2)]:
      └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_group_right_and_included_labels
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_group_right_and_included_labels/disableFallback=true
[*CancellableOperator]: [*vectorOperator] * one-to-many ignoring false group [path]:
├──[*CancellableOperator]: [*coalesceOperator]:
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 0 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 1 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 2 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 3 mod 6
│  ├──[*concurrencyOperator(buff=2)]:
│  │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 4 mod 6
│  └──[*concurrencyOperator(buff=2)]:
│     └──[*CancellableOperator]: [*vectorSelector] {[__name__="bar"]} 5 mod 6
└──[*CancellableOperator]: [*coalesceOperator]:
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 0 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 1 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 2 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 3 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 4 mod 6
   └──[*concurrencyOperator(buff=2)]:
      └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_vector_and_scalar_on_the_right
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_vector_and_scalar_on_the_right/disableFallback=true
[*CancellableOperator]: [*scalarOperator] 2 *:
└──[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*aggregate] sum by ([]):
      └──[*CancellableOperator]: [*coalesceOperator]:
         ├──[*concurrencyOperator(buff=2)]:
         │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 0 mod 6
         ├──[*concurrencyOperator(buff=2)]:
         │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 1 mod 6
         ├──[*concurrencyOperator(buff=2)]:
         │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 2 mod 6
         ├──[*concurrencyOperator(buff=2)]:
         │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 3 mod 6
         ├──[*concurrencyOperator(buff=2)]:
         │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 4 mod 6
         └──[*concurrencyOperator(buff=2)]:
            └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_vector_and_scalar_on_the_left
=== RUN   TestQueriesAgainstOldEngine/binary_operation_with_vector_and_scalar_on_the_left/disableFallback=true
[*CancellableOperator]: [*scalarOperator] 2 *:
└──[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*aggregate] sum by ([]):
      └──[*CancellableOperator]: [*coalesceOperator]:
         ├──[*concurrencyOperator(buff=2)]:
         │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 0 mod 6
         ├──[*concurrencyOperator(buff=2)]:
         │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 1 mod 6
         ├──[*concurrencyOperator(buff=2)]:
         │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 2 mod 6
         ├──[*concurrencyOperator(buff=2)]:
         │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 3 mod 6
         ├──[*concurrencyOperator(buff=2)]:
         │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 4 mod 6
         └──[*concurrencyOperator(buff=2)]:
            └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/complex_binary_operation
=== RUN   TestQueriesAgainstOldEngine/complex_binary_operation/disableFallback=true
[*CancellableOperator]: [*scalarOperator] 1 -:
└──[*CancellableOperator]: [*CancellableOperator]: [*vectorOperator] / one-to-one ignoring false group []:
   ├──[*CancellableOperator]: [*scalarOperator] 100 *:
   │  └──[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
   │     └──[*CancellableOperator]: [*aggregate] sum by ([]):
   │        └──[*CancellableOperator]: [*coalesceOperator]:
   │           ├──[*concurrencyOperator(buff=2)]:
   │           │  └──[*CancellableOperator]: [*vectorSelector] {[method="get" __name__="foo"]} 0 mod 6
   │           ├──[*concurrencyOperator(buff=2)]:
   │           │  └──[*CancellableOperator]: [*vectorSelector] {[method="get" __name__="foo"]} 1 mod 6
   │           ├──[*concurrencyOperator(buff=2)]:
   │           │  └──[*CancellableOperator]: [*vectorSelector] {[method="get" __name__="foo"]} 2 mod 6
   │           ├──[*concurrencyOperator(buff=2)]:
   │           │  └──[*CancellableOperator]: [*vectorSelector] {[method="get" __name__="foo"]} 3 mod 6
   │           ├──[*concurrencyOperator(buff=2)]:
   │           │  └──[*CancellableOperator]: [*vectorSelector] {[method="get" __name__="foo"]} 4 mod 6
   │           └──[*concurrencyOperator(buff=2)]:
   │              └──[*CancellableOperator]: [*vectorSelector] {[method="get" __name__="foo"]} 5 mod 6
   └──[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
      └──[*CancellableOperator]: [*aggregate] sum by ([]):
         └──[*CancellableOperator]: [*coalesceOperator]:
            ├──[*concurrencyOperator(buff=2)]:
            │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 0 mod 6
            ├──[*concurrencyOperator(buff=2)]:
            │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 1 mod 6
            ├──[*concurrencyOperator(buff=2)]:
            │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 2 mod 6
            ├──[*concurrencyOperator(buff=2)]:
            │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 3 mod 6
            ├──[*concurrencyOperator(buff=2)]:
            │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 4 mod 6
            └──[*concurrencyOperator(buff=2)]:
               └──[*CancellableOperator]: [*vectorSelector] {[__name__="foo"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/empty_series
=== RUN   TestQueriesAgainstOldEngine/empty_series/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/empty_series_with_func
=== RUN   TestQueriesAgainstOldEngine/empty_series_with_func/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] sum by ([]):
   └──[*CancellableOperator]: [*coalesceOperator]:
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
      └──[*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/empty_result
=== RUN   TestQueriesAgainstOldEngine/empty_result/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[pod="nginx-3" __name__="http_requests_total"]} 0 mod 6
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[pod="nginx-3" __name__="http_requests_total"]} 1 mod 6
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[pod="nginx-3" __name__="http_requests_total"]} 2 mod 6
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[pod="nginx-3" __name__="http_requests_total"]} 3 mod 6
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[pod="nginx-3" __name__="http_requests_total"]} 4 mod 6
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*vectorSelector] {[pod="nginx-3" __name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/last_over_time
=== RUN   TestQueriesAgainstOldEngine/last_over_time/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] last_over_time({[__name__="http_requests_total"]}[30s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] last_over_time({[__name__="http_requests_total"]}[30s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] last_over_time({[__name__="http_requests_total"]}[30s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] last_over_time({[__name__="http_requests_total"]}[30s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] last_over_time({[__name__="http_requests_total"]}[30s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] last_over_time({[__name__="http_requests_total"]}[30s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/group
=== RUN   TestQueriesAgainstOldEngine/group/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] group by ([]):
   └──[*CancellableOperator]: [*coalesceOperator]:
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
      ├──[*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
      └──[*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/resets
=== RUN   TestQueriesAgainstOldEngine/resets/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] resets({[__name__="http_requests_total"]}[5m0s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] resets({[__name__="http_requests_total"]}[5m0s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] resets({[__name__="http_requests_total"]}[5m0s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] resets({[__name__="http_requests_total"]}[5m0s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] resets({[__name__="http_requests_total"]}[5m0s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] resets({[__name__="http_requests_total"]}[5m0s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/present_over_time
=== RUN   TestQueriesAgainstOldEngine/present_over_time/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] present_over_time({[__name__="http_requests_total"]}[30s] 0 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] present_over_time({[__name__="http_requests_total"]}[30s] 1 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] present_over_time({[__name__="http_requests_total"]}[30s] 2 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] present_over_time({[__name__="http_requests_total"]}[30s] 3 mod 6)
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*matrixSelector] present_over_time({[__name__="http_requests_total"]}[30s] 4 mod 6)
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*matrixSelector] present_over_time({[__name__="http_requests_total"]}[30s] 5 mod 6)
=== RUN   TestQueriesAgainstOldEngine/complex_binary_with_aggregation
=== RUN   TestQueriesAgainstOldEngine/complex_binary_with_aggregation/disableFallback=true
[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
└──[*CancellableOperator]: [*aggregate] sum by ([grpc_method grpc_code]):
   └──[*CancellableOperator]: [*vectorOperator] + many-to-one on [pod] group []:
      ├──[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
      │  └──[*CancellableOperator]: [*aggregate] sum by ([pod grpc_method grpc_code]):
      │     └──[*CancellableOperator]: [*coalesceOperator]:
      │        ├──[*concurrencyOperator(buff=2)]:
      │        │  └──[*CancellableOperator]: [*matrixSelector] rate({[grpc_method="Series" pod=~".+" __name__="grpc_server_handled_total"]}[1m0s] 0 mod 6)
      │        ├──[*concurrencyOperator(buff=2)]:
      │        │  └──[*CancellableOperator]: [*matrixSelector] rate({[grpc_method="Series" pod=~".+" __name__="grpc_server_handled_total"]}[1m0s] 1 mod 6)
      │        ├──[*concurrencyOperator(buff=2)]:
      │        │  └──[*CancellableOperator]: [*matrixSelector] rate({[grpc_method="Series" pod=~".+" __name__="grpc_server_handled_total"]}[1m0s] 2 mod 6)
      │        ├──[*concurrencyOperator(buff=2)]:
      │        │  └──[*CancellableOperator]: [*matrixSelector] rate({[grpc_method="Series" pod=~".+" __name__="grpc_server_handled_total"]}[1m0s] 3 mod 6)
      │        ├──[*concurrencyOperator(buff=2)]:
      │        │  └──[*CancellableOperator]: [*matrixSelector] rate({[grpc_method="Series" pod=~".+" __name__="grpc_server_handled_total"]}[1m0s] 4 mod 6)
      │        └──[*concurrencyOperator(buff=2)]:
      │           └──[*CancellableOperator]: [*matrixSelector] rate({[grpc_method="Series" pod=~".+" __name__="grpc_server_handled_total"]}[1m0s] 5 mod 6)
      └──[*CancellableOperator]: [*concurrencyOperator(buff=2)]:
         └──[*CancellableOperator]: [*aggregate] max by ([pod]):
            └──[*CancellableOperator]: [*coalesceOperator]:
               ├──[*concurrencyOperator(buff=2)]:
               │  └──[*CancellableOperator]: [*vectorSelector] {[pod=~".+" __name__="prometheus_tsdb_head_samples_appended_total"]} 0 mod 6
               ├──[*concurrencyOperator(buff=2)]:
               │  └──[*CancellableOperator]: [*vectorSelector] {[pod=~".+" __name__="prometheus_tsdb_head_samples_appended_total"]} 1 mod 6
               ├──[*concurrencyOperator(buff=2)]:
               │  └──[*CancellableOperator]: [*vectorSelector] {[pod=~".+" __name__="prometheus_tsdb_head_samples_appended_total"]} 2 mod 6
               ├──[*concurrencyOperator(buff=2)]:
               │  └──[*CancellableOperator]: [*vectorSelector] {[pod=~".+" __name__="prometheus_tsdb_head_samples_appended_total"]} 3 mod 6
               ├──[*concurrencyOperator(buff=2)]:
               │  └──[*CancellableOperator]: [*vectorSelector] {[pod=~".+" __name__="prometheus_tsdb_head_samples_appended_total"]} 4 mod 6
               └──[*concurrencyOperator(buff=2)]:
                  └──[*CancellableOperator]: [*vectorSelector] {[pod=~".+" __name__="prometheus_tsdb_head_samples_appended_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/unary_sub_operation_for_scalar
=== RUN   TestQueriesAgainstOldEngine/unary_sub_operation_for_scalar/disableFallback=true
[*CancellableOperator]: [*unaryNegation] !:
└──[*CancellableOperator]: [*scalarOperator] 1 +:
   └──[*CancellableOperator]: [*numberLiteralSelector] 5
=== RUN   TestQueriesAgainstOldEngine/unary_sub_operation_for_vector
=== RUN   TestQueriesAgainstOldEngine/unary_sub_operation_for_vector/disableFallback=true
[*CancellableOperator]: [*unaryNegation] !:
└──[*coalesceOperator]:
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
   └──[*concurrencyOperator(buff=2)]:
      └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
=== RUN   TestQueriesAgainstOldEngine/unary_add_operation_for_vector
=== RUN   TestQueriesAgainstOldEngine/unary_add_operation_for_vector/disableFallback=true
[*CancellableOperator]: [*coalesceOperator]:
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 0 mod 6
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 1 mod 6
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 2 mod 6
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 3 mod 6
├──[*concurrencyOperator(buff=2)]:
│  └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 4 mod 6
└──[*concurrencyOperator(buff=2)]:
   └──[*CancellableOperator]: [*vectorSelector] {[__name__="http_requests_total"]} 5 mod 6
```

</details>