### PR TITLE
engine: print query in case of panic

### DIFF
--- a/engine/range_query.go
+++ b/engine/range_query.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"sort"
 
+	"github.com/go-kit/log"
+
 	"github.com/thanos-community/promql-engine/physicalplan/model"
 
 	"github.com/prometheus/prometheus/promql"
@@ -17,15 +19,24 @@ import (
 type rangeQuery struct {
 	cancel context.CancelFunc
 	plan   model.VectorOperator
+	logger log.Logger
+	expr   parser.Expr
 }
 
-func newRangeQuery(plan model.VectorOperator) promql.Query {
+func newRangeQuery(expr parser.Expr, logger log.Logger, plan model.VectorOperator) promql.Query {
 	return &rangeQuery{
-		plan: plan,
+		logger: logger,
+		plan:   plan,
+		expr:   expr,
 	}
 }
 
-func (q *rangeQuery) Exec(ctx context.Context) *promql.Result {
+func (q *rangeQuery) Exec(ctx context.Context) (ret *promql.Result) {
+	ret = &promql.Result{
+		Value: promql.Vector{},
+	}
+	defer recoverEngine(q.logger, q.expr, &ret.Err)
+
 	ctx, cancel := context.WithCancel(ctx)
 	q.cancel = cancel
 
@@ -33,7 +44,7 @@ func (q *rangeQuery) Exec(ctx context.Context) *promql.Result {
 
 	resultSeries, err := q.plan.Series(ctx)
 	if err != nil {
-		return newErrResult(err)
+		return newErrResult(ret, err)
 	}
 
 	series := make([]promql.Series, len(resultSeries))
@@ -43,20 +54,20 @@ func (q *rangeQuery) Exec(ctx context.Context) *promql.Result {
 	}
 
 	if err := getAllSeries(ctx, q.plan, series); err != nil {
-		return newErrResult(err)
+		return newErrResult(ret, err)
 	}
 
 	result := make(promql.Matrix, 0, len(series))
 	for _, s := range series {
-		if len(s.Points) > 0 {
-			result = append(result, s)
+		if len(s.Points) == 0 {
+			continue
 		}
+		result = append(result, s)
 	}
 
 	sort.Sort(result)
-	return &promql.Result{
-		Value: result,
-	}
+	ret.Value = result
+	return ret
 }
 
 func getAllSeries(ctx context.Context, plan model.VectorOperator, series []promql.Series) error {
@@ -101,6 +112,12 @@ func (q *rangeQuery) Cancel() {
 	}
 }
 
-func newErrResult(err error) *promql.Result {
-	return &promql.Result{Err: err}
+func newErrResult(r *promql.Result, err error) *promql.Result {
+	if r == nil {
+		r = &promql.Result{}
+	}
+	if r.Err == nil && err != nil {
+		r.Err = err
+	}
+	return r
 }


### PR DESCRIPTION
Recover from panics and print the error in case of a panic.

It looks like the following:

```
level=error ts=2022-10-05T08:12:27.931977143Z caller=engine.go:146 msg="runtime panic in parser" expr=sum(up) err="runtime error: invalid memory address or nil pointer dereference" stacktrace="goroutine 45 [running]:\ngithub.com/thanos-community/promql-engine/engine.recoverEngine({0x26ff760, 0xc00011c640}, {0x271d740, 0xc00091c600}, 0xc000926b80)\n\t/home/giedrius/dev/promql-engine/engine/engine.go:144 +0xc6\npanic({0x1eb2580, 0x39b01b0})\n\t/usr/lib/go-1.19/src/runtime/panic.go:884 ...
```

We need to set `*promql.Result` in advance so that later on it wouldn't return `nil` in case of a panic.

This is needed so that we could debug problems in production if / when the engine crashes.

Closes #51.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>