### PR TITLE
Add Explain() to unary operator

### DIFF
--- a/physicalplan/unary/unary.go
+++ b/physicalplan/unary/unary.go
@@ -24,6 +24,10 @@ type unaryNegation struct {
 	workers    worker.Group
 }
 
+func (u *unaryNegation) Explain() (me string, next []model.VectorOperator) {
+	return "[*unaryNegation]", []model.VectorOperator{u.next}
+}
+
 func NewUnaryNegation(
 	next model.VectorOperator,
 	stepsBatch int,


### PR DESCRIPTION
The unary operator has no Explain() method, which breaks some tests and will probably break usage.