### PR TITLE
Fix multi-label hashing

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -176,6 +176,20 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			query: "sum by (pod) (http_requests_total)",
 		},
 		{
+			name: "multi label grouping by",
+			load: `load 30s
+					http_requests_total{pod="nginx-1", ns="a"} 1+1x15
+					http_requests_total{pod="nginx-2", ns="a"} 1+1x15`,
+			query: `avg by (pod, ns) (avg_over_time(http_requests_total[2m]))`,
+		},
+		{
+			name: "multi label grouping without",
+			load: `load 30s
+					http_requests_total{pod="nginx-1", ns="a"} 1+1x15
+					http_requests_total{pod="nginx-2", ns="a"} 1+1x15`,
+			query: `avg without (pod, ns) (avg_over_time(http_requests_total[2m]))`,
+		},
+		{
 			name: "query in the future",
 			load: `load 30s
 					http_requests_total{pod="nginx-1"} 1+1x15
@@ -317,7 +331,7 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 				bar{method="get", path="/a"} 3+7.4x10
 				bar{method="del", path="/b"} 8+6.1x30
 				bar{method="post", path="/c"} 1+2.1x40`,
-			query: `foo * ignoring(code, path) group_left bar`,
+			query: `foo * ignoring(path, code) group_left bar`,
 			start: time.Unix(0, 0),
 			end:   time.Unix(600, 0),
 		},

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/efficientgo/core v1.0.0-rc.0
 	github.com/go-kit/log v0.2.1
 	github.com/prometheus/prometheus v0.38.1-0.20221003141934-f7a7b18cdcca
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	gonum.org/v1/gonum v0.12.0
 )
 
@@ -48,7 +49,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.10.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/goleak v1.2.0 // indirect
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect

--- a/physicalplan/aggregate/hashaggregate.go
+++ b/physicalplan/aggregate/hashaggregate.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/efficientgo/core/errors"
+	"golang.org/x/exp/slices"
 
 	"github.com/thanos-community/promql-engine/physicalplan/parse"
 	"github.com/thanos-community/promql-engine/worker"
@@ -50,6 +51,10 @@ func NewHashAggregate(
 	if err != nil {
 		return nil, err
 	}
+
+	// Grouping labels need to be sorted in order for metric hashing to work.
+	// https://github.com/prometheus/prometheus/blob/8ed39fdab1ead382a354e45ded999eb3610f8d5f/model/labels/labels.go#L162-L181
+	slices.Sort(labels)
 	a := &aggregate{
 		next:           next,
 		vectorPool:     points,


### PR DESCRIPTION
The HashForLabels function from prometheus expects the labels to be provided in sorted order. We don't respect this constraint currently, which leads to multi-label grouping to now work correctly do to series not getting correct hashes.

This commit ensures that all grouping labels are sorted in the binary and hash aggregate operators.