### PR TITLE
Fix performance regression

### DIFF
--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -87,7 +87,7 @@ func BenchmarkSingleQuery(b *testing.B) {
 	end := start.Add(6 * time.Hour)
 	step := time.Second * 30
 
-	query := "sum(http_requests_total)"
+	query := "sum(rate(http_requests_total[2m]))"
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/physicalplan/scan/literal_selector.go
+++ b/physicalplan/scan/literal_selector.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
+
 	"github.com/thanos-community/promql-engine/physicalplan/model"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -108,7 +109,7 @@ func (o *numberLiteralSelector) Next(context.Context) ([]model.StepVector, error
 
 		result := promql.Sample{Point: promql.Point{T: ts, V: o.val}}
 		if o.call != nil {
-			result = o.call(o.series[0], []promql.Point{result.Point}, time.UnixMilli(ts), 0)
+			result = o.call(o.series[0], []promql.Point{result.Point}, ts, 0)
 		}
 
 		vectors[currStep].T = result.T

--- a/physicalplan/scan/matrix_selector.go
+++ b/physicalplan/scan/matrix_selector.go
@@ -136,7 +136,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 			mint := maxt - o.selectRange
 
 			rangePoints := selectPoints(series.samples, mint, maxt, o.scanners[i].previousPoints)
-			result := o.call(series.labels, rangePoints, time.UnixMilli(seriesTs), time.Duration(o.selectRange)*time.Millisecond)
+			result := o.call(series.labels, rangePoints, seriesTs, o.selectRange)
 			if result.Point != InvalidSample.Point {
 				vectors[currStep].T = result.T
 				vectors[currStep].Samples = append(vectors[currStep].Samples, result.V)


### PR DESCRIPTION
Refactoring functions in #60 introduced a regression due to constantly creating new functions in a loop.

This commit revers some of those changes in order to solve the regression. There is a bit more code duplication right now, but we can see how to solve that further down the road.

Current benchmark on main for rate and sum-rate
<pre>
name                                                  old time/op    new time/op    delta
RangeQuery/rate-8                                       51.7ms ± 1%    39.4ms ± 3%    -23.86%  (p=0.000 n=10+10)
RangeQuery/sum_rate-8                                   68.8ms ± 1%    34.4ms ± 1%    -49.98%  (p=0.000 n=10+10)
RangeQuery/sum_by_rate-8                                 148ms ± 1%      40ms ± 1%    -72.96%  (p=0.000 n=10+9)

name                                                  old alloc/op   new alloc/op   delta
RangeQuery/rate-8                                       17.6MB ± 0%   <strong>132.5MB ± 0%   +653.02%</strong>  (p=0.000 n=10+10)
RangeQuery/sum_rate-8                                   6.37MB ± 0%  <strong>115.07MB ± 0%  +1706.88%</strong>  (p=0.000 n=8+10)
RangeQuery/sum_by_rate-8                                80.7MB ± 0%   <strong>122.8MB ± 0%    +52.17%</strong>  (p=0.000 n=9+10)

name                                                  old allocs/op  new allocs/op  delta
RangeQuery/rate-8                                        78.2k ± 0%   <strong>1551.0k ± 0%  +1883.93%</strong> (p=0.000 n=10+10)
RangeQuery/sum_rate-8                                    82.9k ± 0%   <strong>1545.6k ± 0%  +1764.60%</strong>  (p=0.000 n=7+10)
RangeQuery/sum_by_rate-8                                  576k ± 0%     <strong>1631k ± 0%   +183.26%</strong> (p=0.000 n=9+10)
</pre>

Benchmark on this branch
```
RangeQuery/rate-8                                       51.9ms ± 2%    19.5ms ± 1%  -62.39%  (p=0.000 n=10+9)
RangeQuery/sum_rate-8                                   71.2ms ± 2%    14.6ms ± 1%  -79.56%  (p=0.000 n=10+8)
RangeQuery/sum_by_rate-8                                 155ms ± 2%      20ms ± 0%  -87.14%  (p=0.000 n=10+8)

name                                                  old alloc/op   new alloc/op   delta
RangeQuery/rate-8                                       17.6MB ± 0%    28.5MB ± 0%  +62.02%  (p=0.000 n=10+9)
RangeQuery/sum_rate-8                                   6.37MB ± 0%   10.40MB ± 0%  +63.39%  (p=0.000 n=9+8)
RangeQuery/sum_by_rate-8                                80.7MB ± 0%    18.5MB ± 0%  -77.08%  (p=0.000 n=10+8)

name                                                  old allocs/op  new allocs/op  delta
RangeQuery/rate-8                                        78.2k ± 0%    104.9k ± 0%  +34.23%  (p=0.000 n=10+10)
RangeQuery/sum_rate-8                                    82.9k ± 0%     99.3k ± 0%  +19.77%  (p=0.000 n=8+8)
RangeQuery/sum_by_rate-8                                  576k ± 0%      184k ± 0%  -67.98%  (p=0.000 n=10+10)

```