### PR TITLE
Revert "Optimize vector selector (#58)"

### DIFF
--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/prometheus/prometheus/promql"
-
 	"github.com/thanos-community/promql-engine/engine"
 	"github.com/thanos-community/promql-engine/physicalplan/scan"
 )


### PR DESCRIPTION
PR #58 was an attempt to optimize the vector selector and make it run a bit faster. Unfortunately it also introduced a regression which is hard to track down.

For now I will revert this PR and we can revisit the optimization again in the future.

This reverts commit a13c096aaffca82a53259566064ed2898a8b8b1e.