### PR TITLE
Handle out of bounds exception in binary operator

### DIFF
--- a/physicalplan/binary/vector.go
+++ b/physicalplan/binary/vector.go
@@ -155,12 +155,12 @@ func (o *vectorOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 
 	batch := o.pool.GetVectorBatch()
 	for i, vector := range lhs {
-		step := o.table.execBinaryOperation(lhs[i], rhs[i])
-		batch = append(batch, step)
-		o.lhs.GetPool().PutStepVector(vector)
 		if i < len(rhs) {
+			step := o.table.execBinaryOperation(lhs[i], rhs[i])
+			batch = append(batch, step)
 			o.rhs.GetPool().PutStepVector(rhs[i])
 		}
+		o.lhs.GetPool().PutStepVector(vector)
 	}
 	o.lhs.GetPool().PutVectors(lhs)
 	o.rhs.GetPool().PutVectors(rhs)


### PR DESCRIPTION
The vector-to-vector binary operator can throw a panic when the right-hand-side vector is smaller than the left-hand-side vector.

This commit fixes that issue by adding an explicit check for the length of the right-hand-side vector.