### PR TITLE
Consolidate operator arguments

### DIFF
--- a/physicalplan/scan/series_selector.go
+++ b/physicalplan/scan/series_selector.go
@@ -6,6 +6,7 @@ package scan
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -22,8 +23,7 @@ type seriesSelector struct {
 	maxt     int64
 	matchers []*labels.Matcher
 
-	once sync.Once
-
+	once   sync.Once
 	series []signedSeries
 }
 
@@ -71,4 +71,11 @@ func (o *seriesSelector) loadSeries(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func maxDuration(a, b time.Duration) time.Duration {
+	if a.Milliseconds() >= b.Milliseconds() {
+		return a
+	}
+	return b
 }

--- a/physicalplan/step_invariant/step_invariant.go
+++ b/physicalplan/step_invariant/step_invariant.go
@@ -6,13 +6,13 @@ package step_invariant
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/thanos-community/promql-engine/physicalplan/model"
+	"github.com/thanos-community/promql-engine/query"
 )
 
 type stepInvariantOperator struct {
@@ -36,10 +36,9 @@ func NewStepInvariantOperator(
 	pool *model.VectorPool,
 	next model.VectorOperator,
 	expr parser.Expr,
-	mint, maxt time.Time,
-	step time.Duration,
+	opts *query.Options,
 ) (model.VectorOperator, error) {
-	interval := step.Milliseconds()
+	interval := opts.Step.Milliseconds()
 	// We set interval to be at least 1.
 	if interval == 0 {
 		interval = 1
@@ -47,8 +46,8 @@ func NewStepInvariantOperator(
 	u := &stepInvariantOperator{
 		vectorPool:       pool,
 		next:             next,
-		mint:             mint.UnixMilli(),
-		maxt:             maxt.UnixMilli(),
+		mint:             opts.Start.UnixMilli(),
+		maxt:             opts.End.UnixMilli(),
 		step:             interval,
 		duplicateResults: true,
 	}

--- a/physicalplan/unary/unary.go
+++ b/physicalplan/unary/unary.go
@@ -20,8 +20,7 @@ type unaryNegation struct {
 
 	series []labels.Labels
 
-	stepsBatch int
-	workers    worker.Group
+	workers worker.Group
 }
 
 func (u *unaryNegation) Explain() (me string, next []model.VectorOperator) {
@@ -33,8 +32,7 @@ func NewUnaryNegation(
 	stepsBatch int,
 ) (model.VectorOperator, error) {
 	u := &unaryNegation{
-		next:       next,
-		stepsBatch: stepsBatch,
+		next: next,
 	}
 
 	u.workers = worker.NewGroup(stepsBatch, u.workerTask)

--- a/query/options.go
+++ b/query/options.go
@@ -3,11 +3,34 @@
 
 package query
 
-import "time"
+import (
+	"time"
+)
 
 type Options struct {
-	Start time.Time
-	End   time.Time
-	Step  time.Duration
-	Range time.Duration
+	Start         time.Time
+	End           time.Time
+	Step          time.Duration
+	LookbackDelta time.Duration
+
+	StepsBatch int64
+}
+
+func (o *Options) NumSteps() int {
+	// Instant evaluation is executed as a range evaluation with one step.
+	if o.Step.Milliseconds() == 0 {
+		return 1
+	}
+
+	totalSteps := (o.End.UnixMilli()-o.Start.UnixMilli())/o.Step.Milliseconds() + 1
+	if o.StepsBatch < totalSteps {
+		return int(o.StepsBatch)
+	}
+	return int(totalSteps)
+}
+
+func (o *Options) WithEndTime(end time.Time) *Options {
+	result := *o
+	result.End = end
+	return &result
 }


### PR DESCRIPTION
This commit consolidates arguments into various scan operators by using the query.Options data structure to capture arguments and common calculations.