### PR TITLE
Fix trimming of filters in MergeSelects optimizer

### DIFF
--- a/logicalplan/merge_selects.go
+++ b/logicalplan/merge_selects.go
@@ -80,9 +80,13 @@ func replaceMatchers(selectors matcherHeap, expr *parser.Expr) {
 }
 
 func dropMatcher(matcherName string, originalMatchers []*labels.Matcher) []*labels.Matcher {
-	for i, l := range originalMatchers {
+	i := 0
+	for i < len(originalMatchers) {
+		l := originalMatchers[i]
 		if l.Name == matcherName {
 			originalMatchers = append(originalMatchers[:i], originalMatchers[i+1:]...)
+		} else {
+			i++
 		}
 	}
 	return originalMatchers

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -25,6 +25,11 @@ func TestDefaultOptimizers(t *testing.T) {
 			expected: `sum(filter([c="d"], metric{a="b"})) / sum(metric{a="b"})`,
 		},
 		{
+			name:     "common selectors with duplicate matchers",
+			expr:     `sum(metric{a="b", c="d", a="b"}) / sum(metric{a="b"})`,
+			expected: `sum(filter([c="d"], metric{a="b"})) / sum(metric{a="b"})`,
+		},
+		{
 			name:     "common selectors with regex",
 			expr:     `http_requests_total / on () group_left sum(http_requests_total{pod=~"p1.+"})`,
 			expected: `http_requests_total / on () group_left () sum(filter([pod=~"p1.+"], http_requests_total))`,


### PR DESCRIPTION
Trimming filters in the MergeSelectsOptimizer seems to be prone to issues when a vector selector contains duplicate matchers.

This commit addresses that issue.