### PR TITLE
Fix edge case with duplicate matchers

### DIFF
--- a/logicalplan/merge_selects.go
+++ b/logicalplan/merge_selects.go
@@ -57,9 +57,15 @@ func replaceMatchers(selectors matcherHeap, expr *parser.Expr) {
 			if !found {
 				continue
 			}
+
+			// Make a copy of the original selectors to avoid modifying them while
+			// trimming filters.
+			filters := make([]*labels.Matcher, len(e.LabelMatchers))
+			copy(filters, e.LabelMatchers)
+
 			// All replacements are done on metrics name only,
 			// so we can drop the explicit metric name selector.
-			filters := dropMatcher(labels.MetricName, e.LabelMatchers)
+			filters = dropMatcher(labels.MetricName, filters)
 
 			// Drop filters which are already present as matchers in the replacement selector.
 			for _, s := range replacement {
@@ -142,7 +148,7 @@ func (m matcherHeap) findReplacement(metricName string, matcher []*labels.Matche
 	}
 
 	// The top matcher and input matcher are equal. No replacement needed.
-	if len(top) == len(matcherSet) {
+	if len(topSet) == len(matcherSet) {
 		return nil, false
 	}
 

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -30,6 +30,11 @@ func TestDefaultOptimizers(t *testing.T) {
 			expected: `sum(filter([c="d"], metric{a="b"})) / sum(metric{a="b"})`,
 		},
 		{
+			name:     "common selectors with different operators",
+			expr:     `sum(metric{a="b"}) / sum(metric{a=~"b"})`,
+			expected: `sum(metric{a="b"}) / sum(metric{a=~"b"})`,
+		},
+		{
 			name:     "common selectors with regex",
 			expr:     `http_requests_total / on () group_left sum(http_requests_total{pod=~"p1.+"})`,
 			expected: `http_requests_total / on () group_left () sum(filter([pod=~"p1.+"], http_requests_total))`,
@@ -58,6 +63,16 @@ func TestDefaultOptimizers(t *testing.T) {
 			name:     "different metrics",
 			expr:     `sum(metric_1{a="b"}) / sum(metric_2{a="b"})`,
 			expected: `sum(metric_1{a="b"}) / sum(metric_2{a="b"})`,
+		},
+		{
+			name:     "duplicate matchers",
+			expr:     `metric_1{a="1", b="2", a="1"} / metric_2{a="1", b="2", a="1"}`,
+			expected: `metric_1{a="1",a="1",b="2"} / metric_2{a="1",a="1",b="2"}`,
+		},
+		{
+			name:     "duplicate matchers",
+			expr:     `metric_1{a="1", b="2", a="1", e="f"} / metric_1{a="1", b="2", a="1"}`,
+			expected: `filter([e="f"], metric_1{a="1",a="1",b="2"}) / metric_1{a="1",a="1",b="2"}`,
 		},
 	}
 


### PR DESCRIPTION
Duplicate matchers are not properly detected during MergeSelect optimizations. There was also a subtle bug where the original selectors were being modified when trimming filters because they both were pointing at the same slice.

This commit fixes both issues and adds additional unit tests for those cases.