### PR TITLE
execution: fix increase with offset

### DIFF
--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -135,6 +135,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 				Points:      rangePoints,
 				StepTime:    seriesTs,
 				SelectRange: o.selectRange,
+				Offset:      o.offset,
 			})
 
 			if result.Point != function.InvalidSample.Point {


### PR DESCRIPTION
We were not taking offset into account when calculating `extrapolatedRate`. Add a test case to catch this mistake.

Closes #90.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>