### PR TITLE
Return error when iterating a series set

### DIFF
--- a/execution/storage/series_selector.go
+++ b/execution/storage/series_selector.go
@@ -76,7 +76,7 @@ func (o *seriesSelector) loadSeries(ctx context.Context) error {
 		i++
 	}
 
-	return nil
+	return seriesSet.Err()
 }
 
 func seriesShard(series []SignedSeries, shard int, numShards int) []SignedSeries {


### PR DESCRIPTION
The series set may have an error for some reason which was currently being ignored as .Next() would return false and .Err() was never checked.