### PR TITLE
Keep __name__ label when running comparisions

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -480,6 +480,20 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			query: `sum(foo) by (method) > sum(bar) by (method)`,
 		},
 		{
+			name: "vector binary op with name <",
+			load: `load 30s
+				foo{method="get", code="500"} 1+1x40
+				bar{method="get", code="500"} 1+1.1x30`,
+			query: `foo < bar`,
+		},
+		{
+			name: "vector binary op with name < scalar",
+			load: `load 30s
+				foo{method="get", code="500"} 1+1x40
+				bar{method="get", code="500"} 1+1.1x30`,
+			query: `foo < 10`,
+		},
+		{
 			name: "vector binary op > scalar",
 			load: `load 30s
 				foo{method="get", code="500"} 1+2x40

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
+	"github.com/thanos-community/promql-engine/execution/function"
 	"github.com/thanos-community/promql-engine/execution/model"
 )
 
@@ -34,8 +35,7 @@ type scalarOperator struct {
 	getOperands   getOperandsFunc
 	operandValIdx int
 	operation     operation
-	opName        string
-	isComparison  bool
+	opType        parser.ItemType
 }
 
 func NewScalar(
@@ -63,15 +63,14 @@ func NewScalar(
 		next:          next,
 		scalar:        scalar,
 		operation:     binaryOperation,
-		opName:        parser.ItemTypeStr[op],
-		isComparison:  op.IsComparisonOperator(),
+		opType:        op,
 		getOperands:   getOperands,
 		operandValIdx: operandValIdx,
 	}, nil
 }
 
 func (o *scalarOperator) Explain() (me string, next []model.VectorOperator) {
-	return fmt.Sprintf("[*scalarOperator] %s", o.opName), []model.VectorOperator{o.next, o.scalar}
+	return fmt.Sprintf("[*scalarOperator] %s", parser.ItemTypeStr[o.opType]), []model.VectorOperator{o.next, o.scalar}
 }
 
 func (o *scalarOperator) Series(ctx context.Context) ([]labels.Labels, error) {
@@ -147,11 +146,11 @@ func (o *scalarOperator) loadSeries(ctx context.Context) error {
 	series := make([]labels.Labels, len(vectorSeries))
 	for i := range vectorSeries {
 		if vectorSeries[i] != nil {
-			lbls := labels.NewBuilder(vectorSeries[i])
-			if !o.isComparison {
-				lbls = lbls.Del(labels.MetricName)
+			lbls := vectorSeries[i]
+			if !o.opType.IsComparisonOperator() {
+				lbls = function.DropMetricName(lbls)
 			}
-			series[i] = lbls.Labels(nil)
+			series[i] = lbls
 		}
 	}
 

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -35,6 +35,7 @@ type scalarOperator struct {
 	operandValIdx int
 	operation     operation
 	opName        string
+	isComparison  bool
 }
 
 func NewScalar(
@@ -63,6 +64,7 @@ func NewScalar(
 		scalar:        scalar,
 		operation:     binaryOperation,
 		opName:        parser.ItemTypeStr[op],
+		isComparison:  op.IsComparisonOperator(),
 		getOperands:   getOperands,
 		operandValIdx: operandValIdx,
 	}, nil
@@ -145,8 +147,11 @@ func (o *scalarOperator) loadSeries(ctx context.Context) error {
 	series := make([]labels.Labels, len(vectorSeries))
 	for i := range vectorSeries {
 		if vectorSeries[i] != nil {
-			lbls := labels.NewBuilder(vectorSeries[i]).Del(labels.MetricName).Labels(nil)
-			series[i] = lbls
+			lbls := labels.NewBuilder(vectorSeries[i])
+			if !o.isComparison {
+				lbls = lbls.Del(labels.MetricName)
+			}
+			series[i] = lbls.Labels(nil)
 		}
 	}
 


### PR DESCRIPTION
In the case of queries like foo < bar, the result should continue to have the name of the metric, unlike operations such as multiplication.

I am not sure this is the best solution, but it does seem to make the tests pass.