### PR TITLE
Implementing `stddev` and `stdvar` aggregations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following table shows operations which are currently supported by the engine
 |------------------------|------------------------------------------------------------------------------------------|----------|
 | Rate                   | Full support                                                                             |          |
 | Binary expressions     | Full support                                                                             |          |
-| Aggregations           | Partial support (sum, max, min, avg, count and group)                                    | Medium   |
+| Aggregations           | Partial support (sum, max, min, avg, count, group, stddev and stdvar)                    | Medium   |
 | Aggregations over time | Partial support (sum, max, min, avg, count, stddev, stdvar, last and present) _over_time | Medium   |
 | Functions              | No support                                                                               | Medium   |
 | Quantiles              | No support                                                                               | High     |

--- a/execution/aggregate/vector_table.go
+++ b/execution/aggregate/vector_table.go
@@ -5,6 +5,7 @@ package aggregate
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/efficientgo/core/errors"
 
@@ -81,6 +82,27 @@ func newVectorAccumulator(expr parser.ItemType) (vectorAccumulator, error) {
 	case "count":
 		return func(in []float64) float64 {
 			return float64(len(in))
+		}, nil
+	case "stddev":
+	case "stdvar":
+		return func(in []float64) float64 {
+			var groupCount int
+			var mean float64
+			var value float64
+
+			for _, v := range in {
+				groupCount++
+				delta := v - mean
+				mean += delta / float64(groupCount)
+				value += delta * (v - mean)
+			}
+			switch t {
+			case "stdvar":
+				return value / float64(groupCount)
+			case "stddev":
+				return math.Sqrt(value / float64(groupCount))
+			}
+			return 0
 		}, nil
 	case "avg":
 		return func(in []float64) float64 {


### PR DESCRIPTION
Implementing the `stddev` and `stdvar` aggregations based on the prometheus engine implementation:

https://github.com/prometheus/prometheus/blob/fa6e05903fd3ce52e374a6e1bf4eb98c9f1f45a7/promql/engine.go#L2487-L2491

No tests are needed as its already covered on:

https://github.com/thanos-community/promql-engine/blob/1a53dd6b99d8da0502361dcd14437ad18bb098ec/engine/engine_test.go#L955

:D