### PR TITLE
Copy labels before droping metric name

### DIFF
--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -148,7 +148,7 @@ func (o *scalarOperator) loadSeries(ctx context.Context) error {
 		if vectorSeries[i] != nil {
 			lbls := vectorSeries[i]
 			if !o.opType.IsComparisonOperator() {
-				lbls, _ = function.DropMetricName(lbls)
+				lbls, _ = function.DropMetricName(lbls.Copy())
 			}
 			series[i] = lbls
 		}

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -160,7 +160,7 @@ func (o *histogramOperator) loadSeries(ctx context.Context) error {
 	o.outputIndex = make([]histogramSeries, len(series))
 
 	for i, s := range series {
-		lbls, bucketLabel := dropLabel(s, "le")
+		lbls, bucketLabel := dropLabel(s.Copy(), "le")
 		value, err := strconv.ParseFloat(bucketLabel.Value, 64)
 		if err != nil {
 			continue


### PR DESCRIPTION
This is a short term fix, but long term we should modify the function itself to make a copy of input labels.