### PR TITLE
Simplify coalesce operator

### DIFF
--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -29,6 +29,8 @@ type coalesceOperator struct {
 	series []labels.Labels
 
 	pool      *model.VectorPool
+	mu        sync.Mutex
+	wg        sync.WaitGroup
 	operators []model.VectorOperator
 }
 
@@ -64,13 +66,11 @@ func (c *coalesceOperator) Next(ctx context.Context) ([]model.StepVector, error)
 	}
 
 	var out []model.StepVector = nil
-	var wg sync.WaitGroup
-	var mu sync.RWMutex
 	var errChan = make(errorChan, len(c.operators))
 	for _, o := range c.operators {
-		wg.Add(1)
+		c.wg.Add(1)
 		go func(o model.VectorOperator) {
-			defer wg.Done()
+			defer c.wg.Done()
 
 			in, err := o.Next(ctx)
 			if err != nil {
@@ -80,8 +80,8 @@ func (c *coalesceOperator) Next(ctx context.Context) ([]model.StepVector, error)
 			if in == nil {
 				return
 			}
-			mu.Lock()
-			defer mu.Unlock()
+			c.mu.Lock()
+			defer c.mu.Unlock()
 
 			if len(in) > 0 && out == nil {
 				out = c.pool.GetVectorBatch()
@@ -98,7 +98,7 @@ func (c *coalesceOperator) Next(ctx context.Context) ([]model.StepVector, error)
 			o.GetPool().PutVectors(in)
 		}(o)
 	}
-	wg.Wait()
+	c.wg.Wait()
 	close(errChan)
 
 	if err := errChan.getError(); err != nil {


### PR DESCRIPTION
The Coalesce operator uses a RW lock in various places to merge outputs from different operators. Even though it tries to keep critical sections as small as possible, we still end up with the mutex in a locked state the entire time.

This commit simplifies the locking mechanism so that the lock is acquired and released only in one place.

Looks like we even get better performance, probably due to less contention
```
name                                                  old time/op    new time/op    delta
RangeQuery/vector_selector-8                            16.2ms ± 5%    16.4ms ± 3%    ~     (p=0.690 n=5+5)
RangeQuery/sum-8                                        11.0ms ± 7%    10.5ms ± 3%  -4.64%  (p=0.032 n=5+5)
RangeQuery/sum_by_pod-8                                 16.6ms ± 2%    16.4ms ± 6%    ~     (p=0.151 n=5+5)
RangeQuery/rate-8                                       22.8ms ± 2%    22.2ms ± 5%    ~     (p=0.151 n=5+5)
RangeQuery/sum_rate-8                                   17.1ms ± 3%    16.7ms ± 2%    ~     (p=0.151 n=5+5)
RangeQuery/sum_by_rate-8                                23.4ms ± 0%    22.1ms ± 0%  -5.54%  (p=0.008 n=5+5)
RangeQuery/binary_operation_with_one_to_one-8           14.4ms ± 4%    13.4ms ± 0%  -6.91%  (p=0.008 n=5+5)
RangeQuery/binary_operation_with_many_to_one-8          30.6ms ± 4%    27.7ms ± 1%  -9.40%  (p=0.008 n=5+5)
RangeQuery/binary_operation_with_vector_and_scalar-8    19.8ms ± 3%    19.2ms ± 0%  -2.83%  (p=0.008 n=5+5)
RangeQuery/unary_negation-8                             17.1ms ± 4%    16.3ms ± 1%  -4.56%  (p=0.008 n=5+5)
RangeQuery/vector_and_scalar_comparison-8               20.3ms ± 1%    19.7ms ± 0%  -3.28%  (p=0.008 n=5+5)
RangeQuery/positive_offset_vector-8                     14.9ms ± 1%    14.5ms ± 1%  -2.51%  (p=0.008 n=5+5)
RangeQuery/at_modifier_-8                               12.5ms ± 2%    12.5ms ± 2%    ~     (p=0.690 n=5+5)
RangeQuery/at_modifier_with_positive_offset_vector-8    12.0ms ± 2%    11.8ms ± 0%  -1.14%  (p=0.016 n=5+5)
RangeQuery/clamp-8                                      29.0ms ± 5%    28.0ms ± 1%    ~     (p=0.095 n=5+5)
RangeQuery/clamp_min-8                                  24.9ms ± 3%    24.1ms ± 2%    ~     (p=0.056 n=5+5)
RangeQuery/complex_func_query-8                         33.2ms ± 1%    32.7ms ± 1%  -1.44%  (p=0.016 n=5+5)
RangeQuery/func_within_func_query-8                     29.3ms ± 2%    29.0ms ± 2%    ~     (p=0.421 n=5+5)
RangeQuery/aggr_within_func_query-8                     29.7ms ± 5%    29.4ms ± 3%    ~     (p=0.841 n=5+5)
RangeQuery/histogram_quantile-8                          108ms ± 3%     113ms ±30%    ~     (p=0.421 n=5+5)
```