### PR TITLE
Implement matcher propagation

### DIFF
--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 
 	"github.com/thanos-community/promql-engine/engine"
+	"github.com/thanos-community/promql-engine/logicalplan"
 )
 
 func BenchmarkChunkDecoding(b *testing.B) {
@@ -343,7 +344,7 @@ func BenchmarkMergeSelectorsOptimizer(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			opts := engine.Opts{DisableOptimizers: true}
+			opts := engine.Opts{LogicalOptimizers: logicalplan.NoOptimizers}
 			ng := engine.New(opts)
 			qry, err := ng.NewRangeQuery(db, nil, query, start, end, step)
 			testutil.Ok(b, err)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1059,9 +1059,9 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 						for _, disableFallback := range []bool{false, true} {
 							t.Run(fmt.Sprintf("disableFallback=%v", disableFallback), func(t *testing.T) {
 
-								var optimizers = logicalplan.NoOptimizers
-								if !disableOptimizers {
-									optimizers = logicalplan.Optimizers
+								optimizers := logicalplan.AllOptimizers
+								if disableOptimizers {
+									optimizers = logicalplan.NoOptimizers
 								}
 								newEngine := engine.New(engine.Opts{
 									EngineOpts:        opts,
@@ -1837,9 +1837,9 @@ func TestInstantQuery(t *testing.T) {
 									queryTime = tc.queryTime
 								}
 
-								var optimizers = logicalplan.NoOptimizers
-								if !disableOptimizers {
-									optimizers = logicalplan.Optimizers
+								optimizers := logicalplan.AllOptimizers
+								if disableOptimizers {
+									optimizers = logicalplan.NoOptimizers
 								}
 								newEngine := engine.New(engine.Opts{
 									EngineOpts:        opts,

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1059,17 +1059,14 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 						for _, disableFallback := range []bool{false, true} {
 							t.Run(fmt.Sprintf("disableFallback=%v", disableFallback), func(t *testing.T) {
 
-								var additionalOptimizers []logicalplan.Optimizer
+								var optimizers = logicalplan.NoOptimizers
 								if !disableOptimizers {
-									additionalOptimizers = []logicalplan.Optimizer{
-										logicalplan.PropagateMatchersOptimizer{},
-									}
+									optimizers = logicalplan.Optimizers
 								}
 								newEngine := engine.New(engine.Opts{
-									EngineOpts:           opts,
-									DisableFallback:      disableFallback,
-									DisableOptimizers:    disableOptimizers,
-									AdditionalOptimizers: additionalOptimizers,
+									EngineOpts:        opts,
+									DisableFallback:   disableFallback,
+									LogicalOptimizers: optimizers,
 								})
 								q1, err := newEngine.NewRangeQuery(test.Storage(), nil, tc.query, tc.start, tc.end, tc.step)
 								testutil.Ok(t, err)
@@ -1840,17 +1837,14 @@ func TestInstantQuery(t *testing.T) {
 									queryTime = tc.queryTime
 								}
 
-								var additionalOptimizers []logicalplan.Optimizer
+								var optimizers = logicalplan.NoOptimizers
 								if !disableOptimizers {
-									additionalOptimizers = []logicalplan.Optimizer{
-										logicalplan.PropagateMatchersOptimizer{},
-									}
+									optimizers = logicalplan.Optimizers
 								}
 								newEngine := engine.New(engine.Opts{
-									EngineOpts:           opts,
-									DisableFallback:      disableFallback,
-									DisableOptimizers:    disableOptimizers,
-									AdditionalOptimizers: additionalOptimizers,
+									EngineOpts:        opts,
+									DisableFallback:   disableFallback,
+									LogicalOptimizers: optimizers,
 								})
 
 								q1, err := newEngine.NewInstantQuery(test.Storage(), nil, tc.query, queryTime)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/thanos-community/promql-engine/engine"
+	"github.com/thanos-community/promql-engine/logicalplan"
 )
 
 func TestMain(m *testing.M) {
@@ -1057,7 +1058,19 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 					t.Run(fmt.Sprintf("disableOptimizers=%v", disableOptimizers), func(t *testing.T) {
 						for _, disableFallback := range []bool{false, true} {
 							t.Run(fmt.Sprintf("disableFallback=%v", disableFallback), func(t *testing.T) {
-								newEngine := engine.New(engine.Opts{EngineOpts: opts, DisableFallback: disableFallback, DisableOptimizers: disableOptimizers})
+
+								var additionalOptimizers []logicalplan.Optimizer
+								if !disableOptimizers {
+									additionalOptimizers = []logicalplan.Optimizer{
+										logicalplan.PropagateMatchersOptimizer{},
+									}
+								}
+								newEngine := engine.New(engine.Opts{
+									EngineOpts:           opts,
+									DisableFallback:      disableFallback,
+									DisableOptimizers:    disableOptimizers,
+									AdditionalOptimizers: additionalOptimizers,
+								})
 								q1, err := newEngine.NewRangeQuery(test.Storage(), nil, tc.query, tc.start, tc.end, tc.step)
 								testutil.Ok(t, err)
 								defer q1.Close()
@@ -1806,10 +1819,10 @@ func TestInstantQuery(t *testing.T) {
 		},
 	}
 
-	disableOptimizers := []bool{true, false}
+	disableOptimizerOpts := []bool{true, false}
 	lookbackDeltas := []time.Duration{30 * time.Second, time.Minute, 5 * time.Minute, 10 * time.Minute}
-	for _, withoutOptimizers := range disableOptimizers {
-		t.Run(fmt.Sprintf("disableOptimizers=%t", withoutOptimizers), func(t *testing.T) {
+	for _, disableOptimizers := range disableOptimizerOpts {
+		t.Run(fmt.Sprintf("disableOptimizers=%t", disableOptimizers), func(t *testing.T) {
 			for _, lookbackDelta := range lookbackDeltas {
 				opts.LookbackDelta = lookbackDelta
 				for _, tc := range cases {
@@ -1827,7 +1840,19 @@ func TestInstantQuery(t *testing.T) {
 									queryTime = tc.queryTime
 								}
 
-								newEngine := engine.New(engine.Opts{EngineOpts: opts, DisableFallback: disableFallback})
+								var additionalOptimizers []logicalplan.Optimizer
+								if !disableOptimizers {
+									additionalOptimizers = []logicalplan.Optimizer{
+										logicalplan.PropagateMatchersOptimizer{},
+									}
+								}
+								newEngine := engine.New(engine.Opts{
+									EngineOpts:           opts,
+									DisableFallback:      disableFallback,
+									DisableOptimizers:    disableOptimizers,
+									AdditionalOptimizers: additionalOptimizers,
+								})
+
 								q1, err := newEngine.NewInstantQuery(test.Storage(), nil, tc.query, queryTime)
 								testutil.Ok(t, err)
 								defer q1.Close()

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -64,6 +64,7 @@ func traverse(expr *parser.Expr, transform func(*parser.Expr)) {
 			traverse(&n, transform)
 		}
 	case *parser.BinaryExpr:
+		transform(expr)
 		traverse(&node.LHS, transform)
 		traverse(&node.RHS, transform)
 	case *parser.UnaryExpr:

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -10,9 +10,10 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
-var NoOptimizers = []Optimizer{}
-
-var Optimizers = append(DefaultOptimizers, PropagateMatchersOptimizer{})
+var (
+	NoOptimizers  = []Optimizer{}
+	AllOptimizers = append(DefaultOptimizers, PropagateMatchersOptimizer{})
+)
 
 var DefaultOptimizers = []Optimizer{
 	SortMatchers{},

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -10,6 +10,10 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
+var NoOptimizers = []Optimizer{}
+
+var Optimizers = append(DefaultOptimizers, PropagateMatchersOptimizer{})
+
 var DefaultOptimizers = []Optimizer{
 	SortMatchers{},
 	MergeSelectsOptimizer{},

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -89,3 +89,46 @@ func TestDefaultOptimizers(t *testing.T) {
 		})
 	}
 }
+
+func TestMatcherPropagation(t *testing.T) {
+	cases := []struct {
+		name     string
+		expr     string
+		expected string
+	}{
+		{
+			name:     "common matchers with same metric",
+			expr:     `node_filesystem_files{host="$host", mountpoint="/"} - node_filesystem_files`,
+			expected: `node_filesystem_files{host="$host",mountpoint="/"} - node_filesystem_files`,
+		},
+		{
+			name:     "common matchers with same overlapping selectors",
+			expr:     `node_filesystem_files{host="$host", mountpoint="/"} - node_filesystem_files{host!="$host"}`,
+			expected: `node_filesystem_files{host="$host",mountpoint="/"} - node_filesystem_files{host!="$host"}`,
+		},
+		{
+			name:     "common matchers with many-to-one",
+			expr:     `node_filesystem_files{host="$host",mountpoint="/"} - on () group_left () node_filesystem_files_free`,
+			expected: `node_filesystem_files{host="$host",mountpoint="/"} - on () group_left () node_filesystem_files_free`,
+		},
+		{
+			name:     "common matchers",
+			expr:     `node_filesystem_files{host="$host", mountpoint="/"} - node_filesystem_files_free`,
+			expected: `node_filesystem_files{host="$host",mountpoint="/"} - node_filesystem_files_free{host="$host",mountpoint="/"}`,
+		},
+	}
+
+	optimizers := []Optimizer{PropagateMatchersOptimizer{}}
+	spaces := regexp.MustCompile(`\s+`)
+	for _, tcase := range cases {
+		t.Run(tcase.name, func(t *testing.T) {
+			expr, err := parser.ParseExpr(tcase.expr)
+			testutil.Ok(t, err)
+
+			plan := New(expr, time.Unix(0, 0), time.Unix(0, 0))
+			optimizedPlan := plan.Optimize(optimizers)
+			expectedPlan := strings.Trim(spaces.ReplaceAllString(tcase.expected, " "), " ")
+			testutil.Equals(t, expectedPlan, optimizedPlan.Expr().String())
+		})
+	}
+}

--- a/logicalplan/propagate_selectors.go
+++ b/logicalplan/propagate_selectors.go
@@ -1,0 +1,120 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package logicalplan
+
+import (
+	"sort"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// PropagateMatchersOptimizer implements matcher propagation between
+// two vector selectors in a binary expression.
+type PropagateMatchersOptimizer struct{}
+
+func (m PropagateMatchersOptimizer) Optimize(expr parser.Expr) parser.Expr {
+	traverse(&expr, func(expr *parser.Expr) {
+		binOp, ok := (*expr).(*parser.BinaryExpr)
+		if !ok {
+			return
+		}
+
+		// The optimizer cannot be applied to comparison operations.
+		if binOp.Op.IsComparisonOperator() {
+			return
+		}
+
+		// TODO(fpetkovski): Investigate support for vector matching on a subset of labels.
+		if binOp.VectorMatching != nil && len(binOp.VectorMatching.MatchingLabels) > 0 {
+			return
+		}
+
+		// TODO(fpetkovski): Investigate support for one-to-many and many-to-one.
+		if binOp.VectorMatching != nil && binOp.VectorMatching.Card != parser.CardOneToOne {
+			return
+		}
+
+		propagateMatchers(binOp)
+	})
+
+	return expr
+}
+
+func propagateMatchers(binOp *parser.BinaryExpr) {
+	lhSelector, ok := binOp.LHS.(*parser.VectorSelector)
+	if !ok {
+		return
+	}
+	rhSelector, ok := binOp.RHS.(*parser.VectorSelector)
+	if !ok {
+		return
+	}
+	// This case is handled by MergeSelectsOptimizer.
+	if lhSelector.Name == rhSelector.Name {
+		return
+	}
+
+	lhMatchers := toMatcherMap(lhSelector)
+	rhMatchers := toMatcherMap(rhSelector)
+	union, hasDuplicates := makeUnion(lhMatchers, rhMatchers)
+	if hasDuplicates {
+		return
+	}
+
+	finalMatchers := toSlice(union)
+	lhSelector.LabelMatchers = finalMatchers
+	rhSelector.LabelMatchers = finalMatchers
+}
+
+func toSlice(union map[string]*labels.Matcher) []*labels.Matcher {
+	finalMatchers := make([]*labels.Matcher, 0, len(union))
+	for _, m := range union {
+		finalMatchers = append(finalMatchers, m)
+	}
+
+	sort.Slice(finalMatchers, func(i, j int) bool { return finalMatchers[i].Name < finalMatchers[j].Name })
+	return finalMatchers
+}
+
+func makeUnion(lhMatchers map[string]*labels.Matcher, rhMatchers map[string]*labels.Matcher) (map[string]*labels.Matcher, bool) {
+	union := make(map[string]*labels.Matcher)
+	for _, m := range lhMatchers {
+		if m.Name == labels.MetricName {
+			continue
+		}
+		if duplicateExists(rhMatchers, m) {
+			return nil, true
+		}
+		union[m.Name] = m
+	}
+
+	for _, m := range rhMatchers {
+		if m.Name == labels.MetricName {
+			continue
+		}
+		if duplicateExists(lhMatchers, m) {
+			return nil, true
+		}
+		union[m.Name] = m
+	}
+	return union, false
+}
+
+func toMatcherMap(lhSelector *parser.VectorSelector) map[string]*labels.Matcher {
+	lhMatchers := make(map[string]*labels.Matcher)
+	for _, m := range lhSelector.LabelMatchers {
+		lhMatchers[m.Name] = m
+	}
+	return lhMatchers
+}
+
+func duplicateExists(matchers map[string]*labels.Matcher, matcher *labels.Matcher) bool {
+	existing, ok := matchers[matcher.Name]
+	if !ok {
+		return false
+	}
+
+	return existing.String() == matcher.String()
+}


### PR DESCRIPTION
This commit implements matcher propagation between two vector selectors in a binary expression.
The feature is implemented as an opt-in optimizer which can be injected when instantiating the engine.

Let's discuss potential options on how to allow opting into certain optimizations.