### PR TITLE
.github: use self-hosted runner

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   benchmark:
     name: Continuous Benchmark
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Check out code into the Go module directory.
         uses: actions/checkout@v3


### PR DESCRIPTION
I started a small runner on Equinix using CNCF's resources (c3.small.x86). Let's use it to have consistent results.