### PR TITLE
Reduce allocations in aggregate

### DIFF
--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -135,6 +135,10 @@ func BenchmarkRangeQuery(b *testing.B) {
 			query: "sum by (pod) (rate(http_requests_total[1m]))",
 		},
 		{
+			name:  "quantile with variable parameter",
+			query: "quantile by (pod) (scalar(min(http_requests_total)), http_requests_total)",
+		},
+		{
 			name:  "binary operation with one to one",
 			query: `http_requests_total{container="c1"} / ignoring(container) http_responses_total`,
 		},
@@ -356,7 +360,7 @@ func BenchmarkMergeSelectorsOptimizer(b *testing.B) {
 }
 
 func executeRangeQuery(b *testing.B, q string, test *promql.Test, start time.Time, end time.Time, step time.Duration) *promql.Result {
-	return executeRangeQueryWithOpts(b, q, test, start, end, step, engine.Opts{})
+	return executeRangeQueryWithOpts(b, q, test, start, end, step, engine.Opts{DisableFallback: true})
 }
 
 func executeRangeQueryWithOpts(b *testing.B, q string, test *promql.Test, start time.Time, end time.Time, step time.Duration, opts engine.Opts) *promql.Result {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -851,6 +851,16 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			query: `10 + scalar(max(http_requests_total))`,
 		},
 		{
+			name: "quantile",
+			load: `load 30s
+				       http_requests_total{pod="nginx-1", series="1"} 1+1.1x40
+				       http_requests_total{pod="nginx-2", series="2"} 2+2.3x50
+				       http_requests_total{pod="nginx-4", series="3"} 5+2.4x50
+				       http_requests_total{pod="nginx-5", series="1"} 8.4+2.3x50
+				       http_requests_total{pod="nginx-6", series="2"} 2.3+2.3x50	`,
+			query: "quantile(scalar(sum(http_requests_total)), rate(http_requests_total[1m]))",
+		},
+		{
 			name: "clamp",
 			load: `load 30s
 			http_requests_total{pod="nginx-1"} 1+1x15

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -11,10 +11,12 @@ import (
 
 // VectorOperator performs operations on series in step by step fashion.
 type VectorOperator interface {
-	// Next yields stream of samples representing series (vector of multiple series) per one or more steps.
+	// Next yields vectors of samples from all series for one or more execution steps.
 	Next(ctx context.Context) ([]StepVector, error)
 
-	// Series returns all series that we will see in all Next results.
+	// Series returns all series that the operator will process during Next results.
+	// The result can be used by upstream operators to allocate output tables and buffers
+	// before starting to process samples.
 	Series(ctx context.Context) ([]labels.Labels, error)
 
 	// GetPool returns pool of vectors that can be shared across operators.

--- a/execution/model/vector.go
+++ b/execution/model/vector.go
@@ -6,6 +6,8 @@ package model
 import "github.com/prometheus/prometheus/model/labels"
 
 type Series struct {
+	// ID is a numerical, zero-based identifier for a series.
+	// It allows using slices instead of maps for fast lookups.
 	ID     uint64
 	Metric labels.Labels
 }


### PR DESCRIPTION
This commit reduces allocations in the hash aggregate operator by recycling slices from the optional parameter operator and by reusing the same slice to store parameter arguments.

The commit also adds a benchmark for this case.

```
name                                                  old time/op    new time/op    delta
RangeQuery/vector_selector-8                            16.9ms ± 5%    17.4ms ± 6%     ~     (p=0.310 n=5+5)
RangeQuery/sum-8                                        12.0ms ±27%    10.9ms ± 3%     ~     (p=0.222 n=5+5)
RangeQuery/sum_by_pod-8                                 19.6ms ±39%    17.4ms ± 5%     ~     (p=0.310 n=5+5)
RangeQuery/rate-8                                       23.0ms ± 4%    23.0ms ± 1%     ~     (p=0.841 n=5+5)
RangeQuery/sum_rate-8                                   16.9ms ± 2%    17.3ms ± 4%     ~     (p=0.222 n=5+5)
RangeQuery/sum_by_rate-8                                23.9ms ±12%    23.0ms ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/quantile_with_variable_parameter-8           40.1ms ±22%    28.4ms ± 3%  -29.23%  (p=0.008 n=5+5)
```