### PR TITLE
Fix join in binary-operator

### DIFF
--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -232,9 +232,13 @@ func (o *vectorOperator) join(
 			continue
 		}
 	}
+	lowCardOutputSize := 0
+	for _, lowCardOutputs := range lowCardInputIndex {
+		lowCardOutputSize += len(lowCardOutputs)
+	}
 
 	highCardOutputIndex := make([]*uint64, outputSize)
-	lowCardOutputIndex := make([][]uint64, len(lowCardInputIndex))
+	lowCardOutputIndex := make([][]uint64, lowCardOutputSize)
 	for hash, highCardSeries := range highCardHashes {
 		lowCardSeriesID := lowCardInputIndex[hash][0]
 		lowCardSeries := lowCardHashes[hash][0]

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -240,18 +240,22 @@ func (o *vectorOperator) join(
 	highCardOutputIndex := make([]*uint64, outputSize)
 	lowCardOutputIndex := make([][]uint64, lowCardOutputSize)
 	for hash, highCardSeries := range highCardHashes {
-		lowCardSeriesID := lowCardInputIndex[hash][0]
-		lowCardSeries := lowCardHashes[hash][0]
-		// Each low cardinality series can map to multiple output series.
-		lowCardOutputIndex[lowCardSeriesID] = make([]uint64, 0, len(highCardSeries))
+		for _, lowCardSeriesID := range lowCardInputIndex[hash] {
+			// Each low cardinality series can map to multiple output series.
+			lowCardOutputIndex[lowCardSeriesID] = make([]uint64, 0, len(highCardSeries))
+		}
 
+		lowCardSeries := lowCardHashes[hash][0]
 		for i, output := range highCardSeries {
 			outputSeries := buildOutputSeries(uint64(len(outputIndex)), output, lowCardSeries, includeLabels)
 			outputIndex = append(outputIndex, outputSeries)
 
 			highCardSeriesID := highCardInputIndex[hash][i]
 			highCardOutputIndex[highCardSeriesID] = &outputSeries.ID
-			lowCardOutputIndex[lowCardSeriesID] = append(lowCardOutputIndex[lowCardSeriesID], outputSeries.ID)
+
+			for _, lowCardSeriesID := range lowCardInputIndex[hash] {
+				lowCardOutputIndex[lowCardSeriesID] = append(lowCardOutputIndex[lowCardSeriesID], outputSeries.ID)
+			}
 		}
 	}
 


### PR DESCRIPTION
The binary operator assumes that only one low-cardinality series can join any given high-cardinality series since PromQL does not allow many-to-many joins. However, this rule is true only within individual steps. Two low-cardinality time-series can still join the same high-cardinality series if they do not have overlapping samples inside evaluation steps. This can happen during process restarts, where one time-series ends and new one starts.

<img width="1375" alt="image" src="https://user-images.githubusercontent.com/1286231/203806964-04e17102-c7e7-4c6d-a0f5-4db632c80a51.png">

This commit fixes the issue by properly calculating the output buffer for the low-cardinality side in a binop. The case is hard to test right now because the testing framework does not allow for defining offsets for time-series. I tested this in one of our environments and I could not reproduce the original issue anymore.

Fixes https://github.com/thanos-community/promql-engine/issues/127