### PR TITLE
Implement error reporting in binary operator for many-to-many joins

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -465,6 +465,33 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			query: `1 - (100 * sum(foo{method="get"}) / sum(foo))`,
 		},
 		{
+			name: "binary operation with many-to-many matching",
+			load: `load 30s
+				foo{code="200", method="get"} 1+1x20
+				foo{code="200", method="post"} 1+1x20
+				bar{code="200", method="get"} 1+1x20
+				bar{code="200", method="post"} 1+1x20`,
+			query: `foo + on(code) bar`,
+		},
+		{
+			name: "binary operation with many-to-many matching lhs high card",
+			load: `load 30s
+				foo{code="200", method="get"} 1+1x20
+				foo{code="200", method="post"} 1+1x20
+				bar{code="200", method="get"} 1+1x20
+				bar{code="200", method="post"} 1+1x20`,
+			query: `foo + on(code) group_left bar`,
+		},
+		{
+			name: "binary operation with many-to-many matching rhs high card",
+			load: `load 30s
+				foo{code="200", method="get"} 1+1x20
+				foo{code="200", method="post"} 1+1x20
+				bar{code="200", method="get"} 1+1x20
+				bar{code="200", method="post"} 1+1x20`,
+			query: `foo + on(code) group_right bar`,
+		},
+		{
 			name: "vector binary op ==",
 			load: `load 30s
 				foo{method="get", code="500"} 1+1x40

--- a/execution/binary/table.go
+++ b/execution/binary/table.go
@@ -4,7 +4,6 @@
 package binary
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/prometheus/prometheus/promql/parser"
@@ -24,10 +23,6 @@ type errManyToManyMatch struct {
 	sampleID          uint64
 	duplicateSampleID uint64
 	side              binOpSide
-}
-
-func (err errManyToManyMatch) Error() string {
-	return fmt.Sprintf("many-to-many match on %s", err.side)
 }
 
 func newManyToManyMatchError(sampleID, duplicateSampleID uint64, side binOpSide) *errManyToManyMatch {

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -27,11 +27,14 @@ type vectorOperator struct {
 	operation      operation
 	opType         parser.ItemType
 
+	lhSampleIDs []labels.Labels
+	rhSampleIDs []labels.Labels
+
 	// series contains the output series of the operator
 	series []labels.Labels
 	// The outputCache is an internal cache used to calculate
 	// the binary operation of the lhs and rhs operator.
-	outputCache []sample
+	outputCache []outputSample
 	// table is used to calculate the binary operation of two step vectors between
 	// the lhs and rhs operator.
 	table *table
@@ -93,6 +96,9 @@ func (o *vectorOperator) initOutputs(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	o.lhSampleIDs = highCardSide
+	o.rhSampleIDs = lowCardSide
+
 	if o.matching.Card == parser.CardOneToMany {
 		highCardSide, lowCardSide = lowCardSide, highCardSide
 	}
@@ -114,9 +120,9 @@ func (o *vectorOperator) initOutputs(ctx context.Context) error {
 	}
 	o.series = series
 
-	o.outputCache = make([]sample, len(series))
+	o.outputCache = make([]outputSample, len(series))
 	for i := range o.outputCache {
-		o.outputCache[i].t = -1
+		o.outputCache[i].lhT = -1
 	}
 	o.pool.SetStepSize(len(highCardSide))
 
@@ -163,9 +169,26 @@ func (o *vectorOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	batch := o.pool.GetVectorBatch()
 	for i, vector := range lhs {
 		if i < len(rhs) {
-			step := o.table.execBinaryOperation(lhs[i], rhs[i])
-			batch = append(batch, step)
-			o.rhs.GetPool().PutStepVector(rhs[i])
+			step, err := o.table.execBinaryOperation(lhs[i], rhs[i])
+			if err == nil {
+				batch = append(batch, step)
+				o.rhs.GetPool().PutStepVector(rhs[i])
+				continue
+			}
+
+			var sampleID, duplicateSampleID labels.Labels
+			switch err.side {
+			case lhBinOpSide:
+				sampleID = o.lhSampleIDs[err.sampleID]
+				duplicateSampleID = o.lhSampleIDs[err.duplicateSampleID]
+			case rhBinOpSide:
+				sampleID = o.rhSampleIDs[err.sampleID]
+				duplicateSampleID = o.rhSampleIDs[err.duplicateSampleID]
+			}
+			group := sampleID.MatchLabels(o.matching.On, o.matching.MatchingLabels...)
+			msg := "found duplicate series for the match group %s on the %s hand-side of the operation: [%s, %s]" +
+				";many-to-many matching not allowed: matching labels must be unique on one side"
+			return nil, fmt.Errorf(msg, group, err.side, sampleID.String(), duplicateSampleID.String())
 		}
 		o.lhs.GetPool().PutStepVector(vector)
 	}


### PR DESCRIPTION
The engine currently does not report many-to-many matching errors and will likely silently return an incorrect result for such binary operations.

This commit adds support for this detection, similar to how the Prometheus engine reports these errors.

Fixes https://github.com/thanos-community/promql-engine/issues/32

It is not simple to directly compare error messages in tests because the order of the series can be different. For example, we can get failures like this:

expected:
<code>
&errors.errorString{s:"found duplicate series for the match group {code=\"200\"} on the right hand-side of the operation: [{__name__=\"bar\", code=\"200\", method=\"post\"}, {__name__=\"bar\", code=\"200\", method=\"get\"}];many-to-many matching not allowed: matching labels must be unique on one side"}
</code>

got:
<code>
&errors.errorString{s:"found duplicate series for the match group {code=\"200\"} on the right hand-side of the operation: [{__name__=\"bar\", code=\"200\", method=\"get\"}, {__name__=\"bar\", code=\"200\", method=\"post\"}];many-to-many matching not allowed: matching labels must be unique on one side"}
</code>