### PR TITLE
execution: add support for KeepBool

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -576,6 +576,36 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			query: `sum(foo) by (method) % sum(bar) by (method)`,
 		},
 		{
+			name: "vector/vector binary op",
+			load: `load 30s
+					http_requests_total{pod="nginx-1"} 1+1x15
+					http_requests_total{pod="nginx-2"} 1+2x18
+					http_requests_total{pod="nginx-2"} 1+2x18
+					http_requests_total{pod="nginx-2"} 1+2x18
+					http_requests_total{pod="nginx-2"} 1+2x18`,
+			query: "(1 + rate(http_requests_total[30s])) > bool rate(http_requests_total[30s])",
+		},
+		{
+			name: "vector/scalar binary op with a complicated expression on LHS",
+			load: `load 30s
+					http_requests_total{pod="nginx-1"} 1+1x15
+					http_requests_total{pod="nginx-2"} 1+2x18
+					http_requests_total{pod="nginx-2"} 1+2x18
+					http_requests_total{pod="nginx-2"} 1+2x18
+					http_requests_total{pod="nginx-2"} 1+2x18`,
+			query: "rate(http_requests_total[30s]) > bool 0",
+		},
+		{
+			name: "vector/scalar binary op with a complicated expression on RHS",
+			load: `load 30s
+					http_requests_total{pod="nginx-1"} 1+1x15
+					http_requests_total{pod="nginx-2"} 1+2x18
+					http_requests_total{pod="nginx-2"} 1+2x18
+					http_requests_total{pod="nginx-2"} 1+2x18
+					http_requests_total{pod="nginx-2"} 1+2x18`,
+			query: "0 < bool rate(http_requests_total[30s])",
+		},
+		{
 			name:  "scalar binary op == true",
 			load:  ``,
 			query: `1 == bool 1`,
@@ -598,7 +628,7 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 		{
 			name:  "scalar binary op <",
 			load:  ``,
-			query: `1 > bool 2`,
+			query: `1 < bool 2`,
 		},
 		{
 			name:  "scalar binary op >=",

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -36,6 +36,12 @@ type scalarOperator struct {
 	operandValIdx int
 	operation     operation
 	opType        parser.ItemType
+
+	// If true then return the comparison result as 0/1.
+	returnBool bool
+
+	// Keep the result if both sides are scalars.
+	bothScalars bool
 }
 
 func NewScalar(
@@ -44,6 +50,7 @@ func NewScalar(
 	scalar model.VectorOperator,
 	op parser.ItemType,
 	scalarSide ScalarSide,
+	returnBool bool,
 ) (*scalarOperator, error) {
 	binaryOperation, err := newOperation(op, scalarSide != ScalarSideBoth)
 	if err != nil {
@@ -66,6 +73,8 @@ func NewScalar(
 		opType:        op,
 		getOperands:   getOperands,
 		operandValIdx: operandValIdx,
+		returnBool:    returnBool,
+		bothScalars:   scalarSide == ScalarSideBoth,
 	}, nil
 }
 
@@ -117,14 +126,18 @@ func (o *scalarOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 
 			operands := o.getOperands(vector, i, scalarVal)
 			val, keep := o.operation(operands, o.operandValIdx)
-			if !keep {
+			if o.returnBool {
+				if !o.bothScalars {
+					val = 0.0
+					if keep {
+						val = 1.0
+					}
+				}
+			} else if !keep {
 				continue
 			}
 			step.Samples = append(step.Samples, val)
 			step.SampleIDs = append(step.SampleIDs, vector.SampleIDs[i])
-		}
-		if len(step.Samples) == 0 {
-			continue
 		}
 		out = append(out, step)
 		o.next.GetPool().PutStepVector(vector)

--- a/execution/binary/table.go
+++ b/execution/binary/table.go
@@ -83,7 +83,7 @@ func newTable(
 	}
 }
 
-func (t *table) execBinaryOperation(lhs model.StepVector, rhs model.StepVector) (model.StepVector, *errManyToManyMatch) {
+func (t *table) execBinaryOperation(lhs model.StepVector, rhs model.StepVector, returnBool bool) (model.StepVector, *errManyToManyMatch) {
 	ts := lhs.T
 	step := t.pool.GetStepVector(ts)
 
@@ -123,7 +123,12 @@ func (t *table) execBinaryOperation(lhs model.StepVector, rhs model.StepVector) 
 			t.outputValues[outputSampleID].rhT = rhs.T
 
 			outputVal, keep := t.operation([2]float64{outputSample.v, rhVal}, 0)
-			if !keep {
+			if returnBool {
+				outputVal = 0
+				if keep {
+					outputVal = 1
+				}
+			} else if !keep {
 				continue
 			}
 			step.SampleIDs = append(step.SampleIDs, outputSampleID)

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -38,6 +38,9 @@ type vectorOperator struct {
 	// table is used to calculate the binary operation of two step vectors between
 	// the lhs and rhs operator.
 	table *table
+
+	// If true then 1/0 needs to be returned instead of the value.
+	returnBool bool
 }
 
 func NewVectorOperator(
@@ -46,6 +49,7 @@ func NewVectorOperator(
 	rhs model.VectorOperator,
 	matching *parser.VectorMatching,
 	operation parser.ItemType,
+	returnBool bool,
 ) (model.VectorOperator, error) {
 	op, err := newOperation(operation, true)
 	if err != nil {
@@ -66,6 +70,7 @@ func NewVectorOperator(
 		groupingLabels: groupings,
 		operation:      op,
 		opType:         operation,
+		returnBool:     returnBool,
 	}, nil
 }
 
@@ -169,7 +174,7 @@ func (o *vectorOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	batch := o.pool.GetVectorBatch()
 	for i, vector := range lhs {
 		if i < len(rhs) {
-			step, err := o.table.execBinaryOperation(lhs[i], rhs[i])
+			step, err := o.table.execBinaryOperation(lhs[i], rhs[i], o.returnBool)
 			if err == nil {
 				batch = append(batch, step)
 				o.rhs.GetPool().PutStepVector(rhs[i])

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -273,7 +273,7 @@ func newVectorBinaryOperator(e *parser.BinaryExpr, selectorPool *engstore.Select
 	if err != nil {
 		return nil, err
 	}
-	return binary.NewVectorOperator(model.NewVectorPool(stepsBatch), leftOperator, rightOperator, e.VectorMatching, e.Op)
+	return binary.NewVectorOperator(model.NewVectorPool(stepsBatch), leftOperator, rightOperator, e.VectorMatching, e.Op, e.ReturnBool)
 }
 
 func newScalarBinaryOperator(e *parser.BinaryExpr, selectorPool *engstore.SelectorPool, opts *query.Options, hints storage.SelectHints) (model.VectorOperator, error) {
@@ -294,7 +294,7 @@ func newScalarBinaryOperator(e *parser.BinaryExpr, selectorPool *engstore.Select
 		scalarSide = binary.ScalarSideLeft
 	}
 
-	return binary.NewScalar(model.NewVectorPool(stepsBatch), lhs, rhs, e.Op, scalarSide)
+	return binary.NewScalar(model.NewVectorPool(stepsBatch), lhs, rhs, e.Op, scalarSide, e.ReturnBool)
 }
 
 // Copy from https://github.com/prometheus/prometheus/blob/v2.39.1/promql/engine.go#L791.


### PR DESCRIPTION
Add support for "KeepBool"
https://prometheus.io/docs/prometheus/latest/querying/operators/:

tl;dr of the rules:
- If `bool` modifier is provided between scalars then the result is either 0 or 1
- If `bool` modifier is provided between vectors/scalars then the result is 0 if the metric would've been dropped; `__name__` is removed.
- If `bool` modifier is provided between vectors then the result is 0 if the metric would've been dropped; `__name__` is removed.