### PR TITLE
Use efficientgo/core/errors consistently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,12 @@ format: $(GOIMPORTS)
 lint: format deps $(GOLANGCI_LINT) $(FAILLINT) $(COPYRIGHT) docs
 	$(call require_clean_work_tree,'detected not clean work tree before running lint, previous job changed something?')
 	@echo ">> verifying modules being imported"
-	@# TODO(bwplotka): Add, Printf, DefaultRegisterer, NewGaugeFunc and MustRegister once exception are accepted. Add fmt.{Errorf}=github.com/pkg/errors.{Errorf} once https://github.com/fatih/faillint/issues/10 is addressed.
+	@# TODO(bwplotka): Add, Printf, DefaultRegisterer, NewGaugeFunc and MustRegister once exception are accepted.
 	@$(FAILLINT) -paths "errors=github.com/efficientgo/core/errors,\
+fmt.{Errorf}=github.com/efficientgo/core/errors.{Wrap,Wrapf},\
 github.com/prometheus/prometheus/pkg/testutils=github.com/efficientgo/core/testutil,\
 github.com/stretchr/testify=github.com/efficientgo/core/testutil" ./...
-	@$(FAILLINT) -paths "fmt.{Print,Println,Sprint}" -ignore-tests ./...
+	@$(FAILLINT) -paths "fmt.{Print,Println,Sprint,Errorf}" -ignore-tests ./...
 	@echo ">> linting all of the Go files GOGC=${GOGC}"
 	@$(GOLANGCI_LINT) run
 	@echo ">> ensuring Copyright headers"

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -5,7 +5,6 @@ package engine
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"math"
 	"runtime"
@@ -363,7 +362,7 @@ func recoverEngine(logger log.Logger, expr parser.Expr, errp *error) {
 		buf = buf[:runtime.Stack(buf, false)]
 
 		level.Error(logger).Log("msg", "runtime panic in engine", "expr", expr.String(), "err", e, "stacktrace", string(buf))
-		*errp = fmt.Errorf("unexpected error: %w", err)
+		*errp = errors.Wrap(err, "unexpected error")
 	}
 }
 

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"golang.org/x/exp/slices"
@@ -100,7 +101,7 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 	a.paramOp.GetPool().PutVectors(args)
 
 	if len(args) != len(in) {
-		return nil, fmt.Errorf("scalar argument not found")
+		return nil, errors.New("scalar argument not found")
 	}
 
 	a.once.Do(func() { err = a.init(ctx) })

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"golang.org/x/exp/slices"
@@ -193,7 +194,7 @@ func (o *vectorOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 			group := sampleID.MatchLabels(o.matching.On, o.matching.MatchingLabels...)
 			msg := "found duplicate series for the match group %s on the %s hand-side of the operation: [%s, %s]" +
 				";many-to-many matching not allowed: matching labels must be unique on one side"
-			return nil, fmt.Errorf(msg, group, err.side, sampleID.String(), duplicateSampleID.String())
+			return nil, errors.Newf(msg, group, err.side, sampleID.String(), duplicateSampleID.String())
 		}
 		o.lhs.GetPool().PutStepVector(vector)
 	}

--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 
 	"github.com/thanos-community/promql-engine/execution/model"
@@ -21,7 +22,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
-var ErrNativeHistogramsUnsupported = fmt.Errorf("querying native histograms is not supported")
+var ErrNativeHistogramsUnsupported = errors.Newf("querying native histograms is not supported")
 
 type vectorScanner struct {
 	labels    labels.Labels
@@ -178,7 +179,7 @@ func selectPoint(it *storage.MemoizedSeriesIterator, ts, lookbackDelta, offset i
 	case chunkenc.ValFloat:
 		t, v = it.At()
 	default:
-		panic(fmt.Errorf("unknown value type %v", valueType))
+		panic(errors.Newf("unknown value type %v", valueType))
 	}
 	if valueType == chunkenc.ValNone || t > refTime {
 		var ok bool


### PR DESCRIPTION
This PR ensures that we use `efficientgo/core/errors` consistently, and adds lint rules for the same.