### PR TITLE
engine: make histogram_quantile resilient against duplicate output IDs

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1047,7 +1047,7 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			http_requests_total{pod="nginx-2", le="5"} 3+2x10
 			http_requests_total{pod="nginx-1", le="+Inf"} 1+1x10
 			http_requests_total{pod="nginx-2", le="+Inf"} 4+1x10`,
-			query: `histogram_quantile(0.9, sum by (pod, le) (http_requests_total))`,
+			query: `histogram_quantile(0.9, sum by (pod, le) (rate(http_requests_total[2m])))`,
 		},
 		// TODO(fpetkovski): Uncomment once support for testing NaNs is added.
 		//{

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -134,8 +134,12 @@ func (o *histogramOperator) processInputSeries(vectors []model.StepVector) ([]mo
 
 		step := o.pool.GetStepVector(vector.T)
 		for i, stepBuckets := range o.seriesBuckets {
-			// We only have one bucket so it needs to be NaN.
-			// Or, if we are after how many scalar points we have.
+			// It could be zero if multiple input series map to the same output series ID.
+			if len(stepBuckets) == 0 {
+				continue
+			}
+			// If there is only bucket or if we are after how many
+			// scalar points we have then it needs to be NaN.
 			if len(stepBuckets) == 1 || stepIndex >= len(o.scalarPoints) {
 				step.SampleIDs = append(step.SampleIDs, uint64(i))
 				step.Samples = append(step.Samples, math.NaN())


### PR DESCRIPTION
`o.seriesBuckets[i]` can be `nil` if multiple input series IDs map to the output series ID. In such cases, we need to skip over them. 