### PR TITLE
Fix topk/bottomk on empty inputs

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1077,6 +1077,12 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			step:  2 * time.Second,
 		},
 		{
+			name: "topk on empty result",
+			load: `load 30s
+				metric_a 1+1x2`,
+			query: "topk(2, histogram_quantile(0.1, metric_b))",
+		},
+		{
 			name: "topk by",
 			load: `load 30s
 				http_requests_total{pod="nginx-1", series="1"} 1+1.1x40

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -100,7 +100,7 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 	}
 	a.paramOp.GetPool().PutVectors(args)
 
-	if len(args) != len(in) {
+	if len(args) < len(in) {
 		return nil, errors.New("scalar argument not found")
 	}
 


### PR DESCRIPTION
TopK and bottomK can take in empty input vectors in certain cases, which can lead to validation failing in the kHashAggregate operator.

This commit changes the validation to check if the input vector batch has less steps than the scalar vector batch.