### PR TITLE
Fetch Series in parallel for vector operators

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"reflect"
 	"runtime"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -2041,12 +2043,15 @@ func TestQueryCancellation(t *testing.T) {
 
 type hintRecordingQuerier struct {
 	storage.Querier
+	mux   sync.Mutex
 	hints []*storage.SelectHints
 }
 
 func (h *hintRecordingQuerier) Close() error { return nil }
 
 func (h *hintRecordingQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+	h.mux.Lock()
+	defer h.mux.Unlock()
 	h.hints = append(h.hints, hints)
 	return storage.EmptySeriesSet()
 }
@@ -2361,7 +2366,18 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 			res := query.Exec(context.Background())
 			testutil.Ok(t, res.Err)
 
-			testutil.Equals(t, tc.expected, hintsRecorder.hints)
+			// Selects are done in parallel so check that all hints are
+			// present, but order does not matter.
+			testutil.Equals(t, len(tc.expected), len(hintsRecorder.hints))
+			for _, expected := range tc.expected {
+				contains := false
+				for _, hint := range hintsRecorder.hints {
+					if reflect.DeepEqual(expected, hint) {
+						contains = true
+					}
+				}
+				testutil.Assert(t, contains, "hints did not contain contain %#v", expected)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes a TODO in the code, just fetching the Series can be slow in a PromQL server I run and running the operations in parallel can halve the response time.