### PR TITLE
function: add support for time()

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -666,6 +666,11 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			query: "http_requests_total",
 		},
 		{
+			name:  "time function",
+			load:  "",
+			query: "time()",
+		},
+		{
 			name:  "empty series with func",
 			load:  "",
 			query: "sum(http_requests_total)",

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -33,7 +33,7 @@ func FuzzEngineQueryRangeMatrixFunctions(f *testing.F) {
 		}
 		for funcName := range function.Funcs {
 			// Skipping multi-arg functions in fuzz test for now.
-			if len(parser.Functions[funcName].ArgTypes) > 1 || funcName == "scalar" {
+			if len(parser.Functions[funcName].ArgTypes) > 1 || funcName == "scalar" || funcName == "time" {
 				continue
 			}
 

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -159,7 +159,7 @@ func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.O
 			nextOperators[i] = next
 		}
 
-		return function.NewFunctionOperator(e, call, nextOperators, stepsBatch)
+		return function.NewFunctionOperator(e, call, nextOperators, stepsBatch, opts)
 
 	case *parser.AggregateExpr:
 		hints.Func = e.Op.String()

--- a/execution/function/functions.go
+++ b/execution/function/functions.go
@@ -138,6 +138,14 @@ var Funcs = map[string]FunctionCall{
 			},
 		}
 	},
+	"time": func(f FunctionArgs) promql.Sample {
+		return promql.Sample{
+			Point: promql.Point{
+				T: f.StepTime,
+				V: float64(f.StepTime) / 1000,
+			},
+		}
+	},
 	"changes": func(f FunctionArgs) promql.Sample {
 		if len(f.Points) == 0 {
 			return InvalidSample


### PR DESCRIPTION
Add support for time() function. Add special handling for functions that take no input and just return something for each step. It will be used in the future for other date functions.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>