### PR TITLE
Avoid panic in query stats

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -124,7 +124,7 @@ func (e *compatibilityEngine) NewInstantQuery(q storage.Queryable, opts *promql.
 	}
 
 	return &compatibilityQuery{
-		Query:  &Query{exec: exec},
+		Query:  &Query{exec: exec, opts: opts},
 		engine: e,
 		expr:   expr,
 		ts:     ts,
@@ -161,7 +161,7 @@ func (e *compatibilityEngine) NewRangeQuery(q storage.Queryable, opts *promql.Qu
 	}
 
 	return &compatibilityQuery{
-		Query:  &Query{exec: exec},
+		Query:  &Query{exec: exec, opts: opts},
 		engine: e,
 		expr:   expr,
 		t:      RangeQuery,
@@ -170,6 +170,7 @@ func (e *compatibilityEngine) NewRangeQuery(q storage.Queryable, opts *promql.Qu
 
 type Query struct {
 	exec model.VectorOperator
+	opts *promql.QueryOpts
 }
 
 // Explain returns human-readable explanation of the created executor.
@@ -328,7 +329,14 @@ func newErrResult(r *promql.Result, err error) *promql.Result {
 
 func (q *compatibilityQuery) Statement() parser.Statement { return nil }
 
-func (q *compatibilityQuery) Stats() *stats.Statistics { return &stats.Statistics{} }
+// Stats always returns empty query stats for now to avoid panic.
+func (q *compatibilityQuery) Stats() *stats.Statistics {
+	var enablePerStepStats bool
+	if q.opts != nil {
+		enablePerStepStats = q.opts.EnablePerStepStats
+	}
+	return &stats.Statistics{Timers: stats.NewQueryTimers(), Samples: stats.NewQuerySamples(enablePerStepStats)}
+}
 
 func (q *compatibilityQuery) Close() { q.Cancel() }
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -6,6 +6,7 @@ package engine_test
 import (
 	"context"
 	"fmt"
+	"github.com/prometheus/prometheus/util/stats"
 	"math"
 	"os"
 	"reflect"
@@ -2422,6 +2423,34 @@ func TestFallback(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestQueryStats(t *testing.T) {
+	start := time.Unix(0, 0)
+	end := time.Unix(120, 0)
+	step := time.Second * 30
+
+	query := `http_requests_total{pod="nginx-1"}`
+	load := `load 30s
+				http_requests_total{pod="nginx-1"} 1+1x1
+				http_requests_total{pod="nginx-2"} 1+2x1`
+	opts := promql.EngineOpts{
+		Timeout:    2 * time.Second,
+		MaxSamples: math.MaxInt64,
+	}
+
+	test, err := promql.NewTest(t, load)
+	testutil.Ok(t, err)
+	defer test.Close()
+
+	newEngine := engine.New(engine.Opts{DisableFallback: true, EngineOpts: opts})
+	q, err := newEngine.NewRangeQuery(test.Storage(), nil, query, start, end, step)
+	testutil.Ok(t, err)
+	stats.NewQueryStats(q.Stats())
+
+	q, err = newEngine.NewInstantQuery(test.Storage(), nil, query, end)
+	testutil.Ok(t, err)
+	stats.NewQueryStats(q.Stats())
 }
 
 func storageWithSeries(series ...storage.Series) *storage.MockQueryable {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -6,7 +6,6 @@ package engine_test
 import (
 	"context"
 	"fmt"
-	"github.com/prometheus/prometheus/util/stats"
 	"math"
 	"os"
 	"reflect"
@@ -25,6 +24,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/util/stats"
 	"go.uber.org/goleak"
 
 	"github.com/thanos-community/promql-engine/engine"


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

If query stats is required, now the engine would just panic. This pr initializes required field for this API but doesn't implement the query stats feature, just to avoid panic for now.