### PR TITLE
Fix instant query result sort for topk/bottomk

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1676,8 +1676,6 @@ func TestInstantQuery(t *testing.T) {
 						http_requests_total{pod="nginx-8", series="4"} 22
 						http_requests_total{pod="nginx-9", series="4"} 89`,
 			query: "topk(2, http_requests_total)",
-			// TODO (alanprot): Top/BottomK series order on result. https://github.com/thanos-community/promql-engine/issues/120
-			sortByLabels: true,
 		},
 		{
 			name: "topk by series",
@@ -1706,8 +1704,7 @@ func TestInstantQuery(t *testing.T) {
 						http_requests_total{pod="nginx-7", series="3"} 11
 						http_requests_total{pod="nginx-8", series="4"} 22
 						http_requests_total{pod="nginx-9", series="4"} 89`,
-			query:        "bottomk(2, http_requests_total)",
-			sortByLabels: true,
+			query: "bottomk(2, http_requests_total)",
 		},
 		{
 			name: "bottomk by series",


### PR DESCRIPTION
There is an implicit expectation that topk and bottomk instant queries should return values in sorted order. When a grouping is used for these aggregations, results should be sorted within individual groups.

The prometheus engine does not sort the groups themselves, which makes it hard to do exact comparisons. However, we can now compare results directly for these aggregations when no grouping is used.

Fixes https://github.com/thanos-community/promql-engine/issues/120.

cc @alanprot 