### PR TITLE
Fix distributing an aggregation inside a function

### DIFF
--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -119,6 +119,15 @@ dedup(
   remote(rate(http_requests_total[2m]))
 )`,
 		},
+		{
+			name: `histogram quantile`,
+			expr: `histogram_quantile(0.5, sum by (le) (rate(coredns_dns_request_duration_seconds_bucket[5m])))`,
+			expected: `
+histogram_quantile(0.5, sum by (le) (dedup(
+  remote(sum by (le, region) (rate(coredns_dns_request_duration_seconds_bucket[5m]))), 
+  remote(sum by (le, region) (rate(coredns_dns_request_duration_seconds_bucket[5m])))
+)))`,
+		},
 	}
 
 	engines := []api.RemoteEngine{

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -84,6 +84,8 @@ func traverse(expr *parser.Expr, transform func(*parser.Expr)) {
 
 func traverseBottomUp(parent *parser.Expr, current *parser.Expr, transform func(parent *parser.Expr, node *parser.Expr) bool) bool {
 	switch node := (*current).(type) {
+	case *parser.NumberLiteral:
+		return false
 	case *parser.StepInvariantExpr:
 		return traverseBottomUp(current, &node.Expr, transform)
 	case *parser.VectorSelector:
@@ -96,8 +98,8 @@ func traverseBottomUp(parent *parser.Expr, current *parser.Expr, transform func(
 		}
 		return transform(parent, current)
 	case *parser.Call:
-		for _, n := range node.Args {
-			if stop := traverseBottomUp(current, &n, transform); stop {
+		for i := range node.Args {
+			if stop := traverseBottomUp(current, &node.Args[i], transform); stop {
 				return stop
 			}
 		}


### PR DESCRIPTION
The distribute optimizer is passing a reference copy when traversing function arguments. Even when the copy is modified, the original node remains the same. This causes queries with histogram_quantile to get executed in memory instead of getting distributed to remote engines.