### PR TITLE
remove fmt.Sprintf() when writing to hash

### DIFF
--- a/execution/storage/pool.go
+++ b/execution/storage/pool.go
@@ -4,7 +4,6 @@
 package storage
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -68,7 +67,7 @@ func writeMatcher(sb *xxhash.Digest, m *labels.Matcher) {
 }
 
 func writeInt64(sb *xxhash.Digest, val int64) {
-	_, _ = sb.WriteString(fmt.Sprintf("%d", val))
+	_, _ = sb.WriteString(strconv.FormatInt(val, 10))
 	_, _ = sb.Write(sep)
 }
 
@@ -78,6 +77,6 @@ func writeString(sb *xxhash.Digest, val string) {
 }
 
 func writeBool(sb *xxhash.Digest, val bool) {
-	_, _ = sb.WriteString(fmt.Sprintf("%t", val))
+	_, _ = sb.WriteString(strconv.FormatBool(val))
 	_, _ = sb.Write(sep)
 }


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

Fixes https://github.com/thanos-community/promql-engine/issues/159 and use `strconv.Format` instead.
