### PR TITLE
Add link to continuous benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ The current implementation uses goroutines very liberally which means the query 
 
 The current implementation creates a physical plan directly from the PromQL abstract syntax tree. Plan optimizations not yet implemented and would require having a logical plan as an intermediary step.
 
+## Continuous benchmark
+
+If you are interested in the benchmark results captured by continuous benchmark, please check [here](https://thanos-community.github.io/promql-engine/dev/bench/).
+
 ## Latest benchmarks
 
 These are the latest benchmarks captured on an Apple M1 Pro processor.


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

This PR adds the continuous benchmark result to our readme. I don't think current solution is good enough, but okay as a temporary solution.

Would be great to integrate some bots like https://github.com/prometheus/test-infra/tree/master/funcbench for benchmarking.