### PR TITLE
Add tests for distributed instant queries

### DIFF
--- a/api/remote.go
+++ b/api/remote.go
@@ -17,7 +17,6 @@ type RemoteEndpoints interface {
 type RemoteEngine interface {
 	MaxT() int64
 	LabelSets() []labels.Labels
-	NewInstantQuery(opts *promql.QueryOpts, qs string, ts time.Time) (promql.Query, error)
 	NewRangeQuery(opts *promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error)
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -88,10 +88,6 @@ func (l remoteEngine) LabelSets() []labels.Labels {
 	return l.labelSets
 }
 
-func (l remoteEngine) NewInstantQuery(opts *promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {
-	return l.engine.NewInstantQuery(l.q, opts, qs, ts)
-}
-
 func (l remoteEngine) NewRangeQuery(opts *promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error) {
 	return l.engine.NewRangeQuery(l.q, opts, qs, start, end, interval)
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1451,9 +1451,10 @@ func TestDistributedAggregations(t *testing.T) {
 		},
 	}
 
-	start := time.Unix(0, 0)
-	end := time.Unix(120, 0)
-	step := time.Second * 30
+	instantTS := time.Unix(75, 0)
+	rangeStart := time.Unix(0, 0)
+	rangeEnd := time.Unix(120, 0)
+	rangeStep := time.Second * 30
 
 	makeSeries := func(region, pod string) []string {
 		return []string{labels.MetricName, "bar", "region", region, "pod", pod}
@@ -1512,23 +1513,46 @@ func TestDistributedAggregations(t *testing.T) {
 	seriesUnion := storageWithSeries(append(regionEast, regionWest...)...)
 	for _, tcase := range queries {
 		t.Run(tcase.name, func(t *testing.T) {
-			distOpts := localOpts
-			distOpts.DisableFallback = !tcase.expectFallback
-			distEngine := engine.NewDistributedEngine(distOpts,
-				api.NewStaticEndpoints([]api.RemoteEngine{engineEast, engineWest, engineOverlap}),
-			)
-			distQry, err := distEngine.NewRangeQuery(seriesUnion, nil, tcase.query, start, end, step)
-			testutil.Ok(t, err)
+			t.Run("instant", func(t *testing.T) {
+				distOpts := localOpts
+				distOpts.DisableFallback = !tcase.expectFallback
+				distOpts.DebugWriter = os.Stdout
+				distEngine := engine.NewDistributedEngine(distOpts,
+					api.NewStaticEndpoints([]api.RemoteEngine{engineEast, engineWest, engineOverlap}),
+				)
+				distQry, err := distEngine.NewInstantQuery(seriesUnion, nil, tcase.query, instantTS)
+				testutil.Ok(t, err)
 
-			distResult := distQry.Exec(context.Background())
-			promEngine := promql.NewEngine(localOpts.EngineOpts)
-			promQry, err := promEngine.NewRangeQuery(seriesUnion, nil, tcase.query, start, end, step)
-			testutil.Ok(t, err)
-			promResult := promQry.Exec(context.Background())
+				distResult := distQry.Exec(context.Background())
+				promEngine := promql.NewEngine(localOpts.EngineOpts)
+				promQry, err := promEngine.NewInstantQuery(seriesUnion, nil, tcase.query, instantTS)
+				testutil.Ok(t, err)
+				promResult := promQry.Exec(context.Background())
 
-			roundValues(promResult)
-			roundValues(distResult)
-			testutil.Equals(t, promResult, distResult)
+				roundValues(promResult)
+				roundValues(distResult)
+				testutil.Equals(t, promResult, distResult)
+			})
+
+			t.Run("range", func(t *testing.T) {
+				distOpts := localOpts
+				distOpts.DisableFallback = !tcase.expectFallback
+				distEngine := engine.NewDistributedEngine(distOpts,
+					api.NewStaticEndpoints([]api.RemoteEngine{engineEast, engineWest, engineOverlap}),
+				)
+				distQry, err := distEngine.NewRangeQuery(seriesUnion, nil, tcase.query, rangeStart, rangeEnd, rangeStep)
+				testutil.Ok(t, err)
+
+				distResult := distQry.Exec(context.Background())
+				promEngine := promql.NewEngine(localOpts.EngineOpts)
+				promQry, err := promEngine.NewRangeQuery(seriesUnion, nil, tcase.query, rangeStart, rangeEnd, rangeStep)
+				testutil.Ok(t, err)
+				promResult := promQry.Exec(context.Background())
+
+				roundValues(promResult)
+				roundValues(distResult)
+				testutil.Equals(t, promResult, distResult)
+			})
 		})
 	}
 }


### PR DESCRIPTION
This commit adds tests for distributed instant queries. Since an instant query can be expressed as a range query with the same start and end timestamp, this commit also removes the NewInstantQuery method from the remote engine interface in order to keep the API smaller.