### PR TITLE
Ignore optimizers for distributed engine

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -98,10 +98,10 @@ type distributedEngine struct {
 }
 
 func NewDistributedEngine(opts Opts, endpoints api.RemoteEndpoints) v1.QueryEngine {
-	opts.LogicalOptimizers = append(
-		opts.LogicalOptimizers,
+	opts.LogicalOptimizers = []logicalplan.Optimizer{
 		logicalplan.DistributedExecutionOptimizer{Endpoints: endpoints},
-	)
+	}
+
 	return &distributedEngine{
 		endpoints:    endpoints,
 		remoteEngine: New(opts),


### PR DESCRIPTION
The `MergeSelectors` optimizers produces a `FilteredVectorSelector` node whose `String()` method returns an invalid PromQL expression. As a result, this optimizer does not play well with the distributed engine because the remote query will contain the invalid PromQL produced by the filtered selector node.

Looking at the current optimizers we have, none of them are beneficial for the distributed engine since they focus on optimizing selects in binary expressions. Since binary expressions are joins and cannot be distributed, there is no advantage to applying these optimizers in the first place.

Taking these two points into account, this commit simply disables all optimizers when creating an instance of the distributed engine. The `DistributedExecutionOptimizer` will still be applied as before.