### PR TITLE
Add query timeout Support

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -128,8 +128,7 @@ func New(opts Opts) *compatibilityEngine {
 	}
 
 	return &compatibilityEngine{
-		prom:    promql.NewEngine(opts.EngineOpts),
-		timeout: opts.Timeout,
+		prom: promql.NewEngine(opts.EngineOpts),
 		queries: promauto.With(opts.Reg).NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "promql_engine_queries_total",
@@ -141,12 +140,12 @@ func New(opts Opts) *compatibilityEngine {
 		logger:            opts.Logger,
 		lookbackDelta:     opts.LookbackDelta,
 		logicalOptimizers: opts.getLogicalOptimizers(),
+		timeout:           opts.Timeout,
 	}
 }
 
 type compatibilityEngine struct {
 	prom    *promql.Engine
-	timeout time.Duration
 	queries *prometheus.CounterVec
 
 	debugWriter io.Writer
@@ -155,6 +154,7 @@ type compatibilityEngine struct {
 	logger            log.Logger
 	lookbackDelta     time.Duration
 	logicalOptimizers []logicalplan.Optimizer
+	timeout           time.Duration
 }
 
 func (e *compatibilityEngine) SetQueryLogger(l promql.QueryLogger) {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2539,9 +2539,7 @@ func TestQueryCancellation(t *testing.T) {
 }
 
 func TestQueryTimeout(t *testing.T) {
-
 	end := time.Unix(120, 0)
-
 	query := `http_requests_total{pod="nginx-1"}`
 	load := `load 30s
 				http_requests_total{pod="nginx-1"} 1+1x1

--- a/engine/existing_test.go
+++ b/engine/existing_test.go
@@ -117,7 +117,10 @@ func TestRangeQuery(t *testing.T) {
 		},
 	}
 
-	ng := engine.New(engine.Opts{})
+	opts := promql.EngineOpts{
+		Timeout: 1 * time.Hour,
+	}
+	ng := engine.New(engine.Opts{EngineOpts: opts})
 
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #146 

Current engine doesn't support query timeout, which was a part of original promql-engine.
This Pull Request adds timeout option in `compatibilityEngine`, as our engine can't access
private data member `timeout` of the `promql.Engine`.

Testcase are updated as well.