### PR TITLE
Add support for histogram aggregates

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -3193,7 +3193,7 @@ func TestNativeHistogram(t *testing.T) {
 			query: "count by (foo) (native_histogram_series)",
 		},
 		// TODO(fpetkovski): The Prometheus engine returns an incorrect result for this case.
-		// Uncomment once it gets fixed.
+		// Uncomment once it gets fixed: https://github.com/prometheus/prometheus/issues/11973.
 		//{
 		//	name:  "max",
 		//	query: "max (native_histogram_series)",
@@ -3203,7 +3203,7 @@ func TestNativeHistogram(t *testing.T) {
 			query: "max by (foo) (native_histogram_series)",
 		},
 		// TODO(fpetkovski): The Prometheus engine returns an incorrect result for this case.
-		// Uncomment once it gets fixed.
+		// Uncomment once it gets fixed: https://github.com/prometheus/prometheus/issues/11973.
 		//{
 		//	name:  "min",
 		//	query: "min (native_histogram_series)",

--- a/execution/aggregate/scalar_table.go
+++ b/execution/aggregate/scalar_table.go
@@ -8,6 +8,8 @@ import (
 	"math"
 	"sort"
 
+	"github.com/prometheus/prometheus/model/histogram"
+
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -56,6 +58,9 @@ func (t *scalarTable) aggregate(arg float64, vector model.StepVector) {
 	for i := range vector.Samples {
 		t.addSample(vector.T, vector.SampleIDs[i], vector.Samples[i])
 	}
+	for i := range vector.Histograms {
+		t.addHistogram(vector.T, vector.HistogramIDs[i], vector.Histograms[i])
+	}
 }
 
 func (t *scalarTable) addSample(ts int64, sampleID uint64, sample float64) {
@@ -63,7 +68,15 @@ func (t *scalarTable) addSample(ts int64, sampleID uint64, sample float64) {
 	output := t.outputs[outputSampleID]
 
 	t.timestamp = ts
-	t.accumulators[output.ID].AddFunc(sample)
+	t.accumulators[output.ID].AddFunc(sample, nil)
+}
+
+func (t *scalarTable) addHistogram(ts int64, sampleID uint64, h *histogram.FloatHistogram) {
+	outputSampleID := t.inputs[sampleID]
+	output := t.outputs[outputSampleID]
+
+	t.timestamp = ts
+	t.accumulators[output.ID].AddFunc(0, h)
 }
 
 func (t *scalarTable) reset(arg float64) {
@@ -76,7 +89,12 @@ func (t *scalarTable) toVector(pool *model.VectorPool) model.StepVector {
 	result := pool.GetStepVector(t.timestamp)
 	for i, v := range t.outputs {
 		if t.accumulators[i].HasValue() {
-			result.AppendSample(pool, v.ID, t.accumulators[i].ValueFunc())
+			f, h := t.accumulators[i].ValueFunc()
+			if h == nil {
+				result.AppendSample(pool, v.ID, f)
+			} else {
+				result.AppendHistogram(pool, v.ID, h)
+			}
 		}
 	}
 	return result
@@ -108,8 +126,8 @@ func hashMetric(metric labels.Labels, without bool, grouping []string, buf []byt
 type newAccumulatorFunc func() *accumulator
 
 type accumulator struct {
-	AddFunc   func(v float64)
-	ValueFunc func() float64
+	AddFunc   func(v float64, h *histogram.FloatHistogram)
+	ValueFunc func() (float64, *histogram.FloatHistogram)
 	HasValue  func() bool
 	Reset     func(arg float64)
 }
@@ -120,17 +138,29 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 	case "sum":
 		return func() *accumulator {
 			var value float64
-			var hasValue bool
+			var histSum *histogram.FloatHistogram
+			var hasFloatVal bool
 
 			return &accumulator{
-				AddFunc: func(v float64) {
-					hasValue = true
-					value += v
+				AddFunc: func(v float64, h *histogram.FloatHistogram) {
+					if h == nil {
+						hasFloatVal = true
+						value += v
+						return
+					}
+					if histSum == nil {
+						histSum = h
+						return
+					}
+					histSum = histSum.Add(h)
 				},
-				ValueFunc: func() float64 { return value },
-				HasValue:  func() bool { return hasValue },
+				ValueFunc: func() (float64, *histogram.FloatHistogram) {
+					return value, histSum
+				},
+				// Sum returns an empty result when floats are histograms are aggregated.
+				HasValue: func() bool { return hasFloatVal != (histSum != nil) },
 				Reset: func(_ float64) {
-					hasValue = false
+					hasFloatVal = false
 					value = 0
 				},
 			}
@@ -141,7 +171,7 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 			var hasValue bool
 
 			return &accumulator{
-				AddFunc: func(v float64) {
+				AddFunc: func(v float64, _ *histogram.FloatHistogram) {
 					if !hasValue {
 						value = v
 					} else {
@@ -149,8 +179,10 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 					}
 					hasValue = true
 				},
-				ValueFunc: func() float64 { return value },
-				HasValue:  func() bool { return hasValue },
+				ValueFunc: func() (float64, *histogram.FloatHistogram) {
+					return value, nil
+				},
+				HasValue: func() bool { return hasValue },
 				Reset: func(_ float64) {
 					hasValue = false
 					value = 0
@@ -163,7 +195,7 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 			var hasValue bool
 
 			return &accumulator{
-				AddFunc: func(v float64) {
+				AddFunc: func(v float64, _ *histogram.FloatHistogram) {
 					if !hasValue {
 						value = v
 					} else {
@@ -171,8 +203,10 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 					}
 					hasValue = true
 				},
-				ValueFunc: func() float64 { return value },
-				HasValue:  func() bool { return hasValue },
+				ValueFunc: func() (float64, *histogram.FloatHistogram) {
+					return value, nil
+				},
+				HasValue: func() bool { return hasValue },
 				Reset: func(_ float64) {
 					hasValue = false
 					value = 0
@@ -185,12 +219,14 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 			var hasValue bool
 
 			return &accumulator{
-				AddFunc: func(v float64) {
+				AddFunc: func(_ float64, _ *histogram.FloatHistogram) {
 					hasValue = true
 					value += 1
 				},
-				ValueFunc: func() float64 { return value },
-				HasValue:  func() bool { return hasValue },
+				ValueFunc: func() (float64, *histogram.FloatHistogram) {
+					return value, nil
+				},
+				HasValue: func() bool { return hasValue },
 				Reset: func(_ float64) {
 					hasValue = false
 					value = 0
@@ -203,13 +239,15 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 			var hasValue bool
 
 			return &accumulator{
-				AddFunc: func(v float64) {
+				AddFunc: func(v float64, _ *histogram.FloatHistogram) {
 					hasValue = true
 					count += 1
 					sum += v
 				},
-				ValueFunc: func() float64 { return sum / count },
-				HasValue:  func() bool { return hasValue },
+				ValueFunc: func() (float64, *histogram.FloatHistogram) {
+					return sum / count, nil
+				},
+				HasValue: func() bool { return hasValue },
 				Reset: func(_ float64) {
 					hasValue = false
 					sum = 0
@@ -221,11 +259,13 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 		return func() *accumulator {
 			var hasValue bool
 			return &accumulator{
-				AddFunc: func(v float64) {
+				AddFunc: func(_ float64, _ *histogram.FloatHistogram) {
 					hasValue = true
 				},
-				ValueFunc: func() float64 { return 1 },
-				HasValue:  func() bool { return hasValue },
+				ValueFunc: func() (float64, *histogram.FloatHistogram) {
+					return 1, nil
+				},
+				HasValue: func() bool { return hasValue },
 				Reset: func(_ float64) {
 					hasValue = false
 				},
@@ -238,15 +278,17 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 			var aux, cAux float64
 			var hasValue bool
 			return &accumulator{
-				AddFunc: func(v float64) {
+				AddFunc: func(v float64, _ *histogram.FloatHistogram) {
 					hasValue = true
 					count++
 					delta := v - (mean + cMean)
 					mean, cMean = function.KahanSumInc(delta/count, mean, cMean)
 					aux, cAux = function.KahanSumInc(delta*(v-(mean+cMean)), aux, cAux)
 				},
-				ValueFunc: func() float64 { return math.Sqrt((aux + cAux) / count) },
-				HasValue:  func() bool { return hasValue },
+				ValueFunc: func() (float64, *histogram.FloatHistogram) {
+					return math.Sqrt((aux + cAux) / count), nil
+				},
+				HasValue: func() bool { return hasValue },
 				Reset: func(_ float64) {
 					hasValue = false
 					count = 0
@@ -264,15 +306,17 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 			var aux, cAux float64
 			var hasValue bool
 			return &accumulator{
-				AddFunc: func(v float64) {
+				AddFunc: func(v float64, _ *histogram.FloatHistogram) {
 					hasValue = true
 					count++
 					delta := v - (mean + cMean)
 					mean, cMean = function.KahanSumInc(delta/count, mean, cMean)
 					aux, cAux = function.KahanSumInc(delta*(v-(mean+cMean)), aux, cAux)
 				},
-				ValueFunc: func() float64 { return (aux + cAux) / count },
-				HasValue:  func() bool { return hasValue },
+				ValueFunc: func() (float64, *histogram.FloatHistogram) {
+					return (aux + cAux) / count, nil
+				},
+				HasValue: func() bool { return hasValue },
 				Reset: func(_ float64) {
 					hasValue = false
 					count = 0
@@ -289,12 +333,12 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 			var arg float64
 			points := make([]float64, 0)
 			return &accumulator{
-				AddFunc: func(v float64) {
+				AddFunc: func(v float64, _ *histogram.FloatHistogram) {
 					hasValue = true
 					points = append(points, v)
 				},
-				ValueFunc: func() float64 {
-					return quantile(arg, points)
+				ValueFunc: func() (float64, *histogram.FloatHistogram) {
+					return quantile(arg, points), nil
 				},
 				HasValue: func() bool { return hasValue },
 				Reset: func(a float64) {

--- a/execution/aggregate/vector_table.go
+++ b/execution/aggregate/vector_table.go
@@ -6,6 +6,8 @@ package aggregate
 import (
 	"fmt"
 
+	"github.com/prometheus/prometheus/model/histogram"
+
 	"github.com/efficientgo/core/errors"
 
 	"github.com/prometheus/prometheus/promql/parser"
@@ -15,10 +17,11 @@ import (
 	"github.com/thanos-community/promql-engine/execution/parse"
 )
 
-type vectorAccumulator func([]float64) float64
+type vectorAccumulator func([]float64, []*histogram.FloatHistogram) (float64, *histogram.FloatHistogram, bool)
 
 type vectorTable struct {
 	timestamp   int64
+	histValue   *histogram.FloatHistogram
 	value       float64
 	hasValue    bool
 	accumulator vectorAccumulator
@@ -44,13 +47,18 @@ func newVectorizedTable(a vectorAccumulator) *vectorTable {
 }
 
 func (t *vectorTable) aggregate(_ float64, vector model.StepVector) {
-	if len(vector.SampleIDs) == 0 {
+	if len(vector.SampleIDs) == 0 && len(vector.Histograms) == 0 {
 		t.hasValue = false
 		return
 	}
+
 	t.hasValue = true
 	t.timestamp = vector.T
-	t.value = t.accumulator(vector.Samples)
+	var ok bool
+	t.value, t.histValue, ok = t.accumulator(vector.Samples, vector.Histograms)
+	if !ok {
+		t.hasValue = false
+	}
 }
 
 func (t *vectorTable) toVector(pool *model.VectorPool) model.StepVector {
@@ -58,7 +66,11 @@ func (t *vectorTable) toVector(pool *model.VectorPool) model.StepVector {
 	if !t.hasValue {
 		return result
 	}
-	result.AppendSample(pool, 0, t.value)
+	if t.histValue == nil {
+		result.AppendSample(pool, 0, t.value)
+	} else {
+		result.AppendHistogram(pool, 0, t.histValue)
+	}
 	return result
 }
 
@@ -70,24 +82,58 @@ func newVectorAccumulator(expr parser.ItemType) (vectorAccumulator, error) {
 	t := parser.ItemTypeStr[expr]
 	switch t {
 	case "sum":
-		return floats.Sum, nil
+		return func(float64s []float64, histograms []*histogram.FloatHistogram) (float64, *histogram.FloatHistogram, bool) {
+			// Summing up mixed types is not defined.
+			if len(float64s) != 0 && len(histograms) != 0 {
+				return 0, nil, false
+			}
+			if len(float64s) > 0 {
+				return floats.Sum(float64s), nil, true
+			}
+			return 0, histogramSum(histograms), true
+		}, nil
 	case "max":
-		return floats.Max, nil
+		return func(float64s []float64, hs []*histogram.FloatHistogram) (float64, *histogram.FloatHistogram, bool) {
+			if len(float64s) > 0 {
+				return floats.Max(float64s), nil, true
+			}
+			return 0, nil, false
+		}, nil
 	case "min":
-		return floats.Min, nil
+		return func(float64s []float64, hs []*histogram.FloatHistogram) (float64, *histogram.FloatHistogram, bool) {
+			if len(float64s) > 0 {
+				return floats.Min(float64s), nil, true
+			}
+			return 0, nil, false
+		}, nil
 	case "count":
-		return func(in []float64) float64 {
-			return float64(len(in))
+		return func(in []float64, hs []*histogram.FloatHistogram) (float64, *histogram.FloatHistogram, bool) {
+			return float64(len(in)) + float64(len(hs)), nil, true
 		}, nil
 	case "avg":
-		return func(in []float64) float64 {
-			return floats.Sum(in) / float64(len(in))
+		return func(float64s []float64, histograms []*histogram.FloatHistogram) (float64, *histogram.FloatHistogram, bool) {
+			if len(float64s) > 0 {
+				return floats.Sum(float64s) / float64(len(float64s)), nil, true
+			}
+			return 0, nil, false
 		}, nil
 	case "group":
-		return func(in []float64) float64 {
-			return 1
+		return func(float64s []float64, histograms []*histogram.FloatHistogram) (float64, *histogram.FloatHistogram, bool) {
+			return 1, nil, true
 		}, nil
 	}
 	msg := fmt.Sprintf("unknown aggregation function %s", t)
 	return nil, errors.Wrap(parse.ErrNotSupportedExpr, msg)
+}
+
+func histogramSum(histograms []*histogram.FloatHistogram) *histogram.FloatHistogram {
+	if len(histograms) == 1 {
+		return histograms[0]
+	}
+
+	histSum := histograms[0]
+	for i := 1; i < len(histograms); i++ {
+		histSum = histSum.Add(histograms[i])
+	}
+	return histSum
 }

--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -182,8 +182,7 @@ func selectPoint(it *storage.MemoizedSeriesIterator, ts, lookbackDelta, offset i
 	case chunkenc.ValFloatHistogram:
 		return 0, 0, nil, false, ErrNativeHistogramsUnsupported
 	case chunkenc.ValHistogram:
-		t, h := it.AtHistogram()
-		return t, 0, h.ToFloat(), true, nil
+		t, h = it.AtFloatHistogram()
 	case chunkenc.ValFloat:
 		t, v = it.At()
 	default:


### PR DESCRIPTION
This commit adds support for aggregating native histograms. The behavior is currently defined for the `sum`, `count` and `group` aggregations.

Aggregations like `avg`, `max`, `min`, etc.. currently return incorrect results in the Prometheus engine.