### PR TITLE
Add support for native histogram functions

### DIFF
--- a/execution/function/functions.go
+++ b/execution/function/functions.go
@@ -394,6 +394,42 @@ var Funcs = map[string]FunctionCall{
 			},
 		}
 	},
+	"histogram_sum": func(f FunctionArgs) promql.Sample {
+		if len(f.Points) == 0 || f.Points[0].H == nil {
+			return InvalidSample
+		}
+		return promql.Sample{
+			Metric: f.Labels,
+			Point: promql.Point{
+				T: f.StepTime,
+				V: f.Points[0].H.Sum,
+			},
+		}
+	},
+	"histogram_count": func(f FunctionArgs) promql.Sample {
+		if len(f.Points) == 0 || f.Points[0].H == nil {
+			return InvalidSample
+		}
+		return promql.Sample{
+			Metric: f.Labels,
+			Point: promql.Point{
+				T: f.StepTime,
+				V: f.Points[0].H.Count,
+			},
+		}
+	},
+	"histogram_fraction": func(f FunctionArgs) promql.Sample {
+		if len(f.Points) == 0 || f.Points[0].H == nil {
+			return InvalidSample
+		}
+		return promql.Sample{
+			Metric: f.Labels,
+			Point: promql.Point{
+				T: f.StepTime,
+				V: histogramFraction(f.ScalarPoints[0], f.ScalarPoints[1], f.Points[0].H),
+			},
+		}
+	},
 	"days_in_month": func(f FunctionArgs) promql.Sample {
 		return dateWrapper(f, func(t time.Time) float64 {
 			return float64(32 - time.Date(t.Year(), t.Month(), 32, 0, 0, 0, 0, time.UTC).Day())

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -18,8 +18,9 @@ import (
 )
 
 type histogramSeries struct {
-	outputID   int
-	upperBound float64
+	outputID       int
+	upperBound     float64
+	hasBucketValue bool
 }
 
 // histogramOperator is a function operator that calculates percentiles.
@@ -41,7 +42,7 @@ type histogramOperator struct {
 	// If outputIndex[i] is nil then series[i] has no valid `le` label.
 	outputIndex []*histogramSeries
 
-	// seriesBuckets are the buckets for each individual series.
+	// seriesBuckets are the buckets for each individual conventional histogram series.
 	seriesBuckets []buckets
 }
 
@@ -121,9 +122,10 @@ func (o *histogramOperator) processInputSeries(vectors []model.StepVector) ([]mo
 		for i, seriesID := range vector.SampleIDs {
 			outputSeries := o.outputIndex[seriesID]
 			// This means that it has an invalid `le` label.
-			if outputSeries == nil {
+			if outputSeries == nil || !outputSeries.hasBucketValue {
 				continue
 			}
+
 			outputSeriesID := outputSeries.outputID
 			bucket := le{
 				upperBound: outputSeries.upperBound,
@@ -133,6 +135,20 @@ func (o *histogramOperator) processInputSeries(vectors []model.StepVector) ([]mo
 		}
 
 		step := o.pool.GetStepVector(vector.T)
+		for i, seriesID := range vector.HistogramIDs {
+			outputSeriesID := o.outputIndex[seriesID].outputID
+			// We need to check if there is a conventional histogram mapped to this output series ID.
+			// If that is the case, it means we have mixed data types for a single step and this behavior is undefined.
+			// In that case, we reset the conventional buckets to avoid emitting a sample.
+			// TODO(fpetkovski): Prometheus is looking to solve these conflicts through warnings: https://github.com/prometheus/prometheus/issues/10839.
+			if len(o.seriesBuckets[outputSeriesID]) == 0 {
+				value := histogramQuantile(o.scalarPoints[stepIndex], vector.Histograms[i])
+				step.AppendSample(o.pool, uint64(outputSeriesID), value)
+			} else {
+				o.seriesBuckets[outputSeriesID] = o.seriesBuckets[outputSeriesID][:0]
+			}
+		}
+
 		for i, stepBuckets := range o.seriesBuckets {
 			// It could be zero if multiple input series map to the same output series ID.
 			if len(stepBuckets) == 0 {
@@ -173,10 +189,11 @@ func (o *histogramOperator) loadSeries(ctx context.Context) error {
 	o.outputIndex = make([]*histogramSeries, len(series))
 
 	for i, s := range series {
+		hasBucketValue := true
 		lbls, bucketLabel := dropLabel(s.Copy(), "le")
 		value, err := strconv.ParseFloat(bucketLabel.Value, 64)
 		if err != nil {
-			continue
+			hasBucketValue = false
 		}
 		lbls, _ = DropMetricName(lbls)
 
@@ -195,8 +212,9 @@ func (o *histogramOperator) loadSeries(ctx context.Context) error {
 		}
 
 		o.outputIndex[i] = &histogramSeries{
-			outputID:   seriesID,
-			upperBound: value,
+			outputID:       seriesID,
+			upperBound:     value,
+			hasBucketValue: hasBucketValue,
 		}
 	}
 	o.seriesBuckets = make([]buckets, len(o.series))

--- a/execution/model/vector.go
+++ b/execution/model/vector.go
@@ -43,6 +43,11 @@ func (s *StepVector) AppendSamples(pool *VectorPool, ids []uint64, vals []float6
 	s.Samples = append(s.Samples, vals...)
 }
 
+func (s *StepVector) RemoveSample(index int) {
+	s.Samples = append(s.Samples[:index], s.Samples[index+1:]...)
+	s.SampleIDs = append(s.SampleIDs[:index], s.SampleIDs[index+1:]...)
+}
+
 func (s *StepVector) AppendHistogram(pool *VectorPool, histogramID uint64, h *histogram.FloatHistogram) {
 	if s.Histograms == nil {
 		s.HistogramIDs, s.Histograms = pool.getHistogramBuffers()
@@ -60,4 +65,9 @@ func (s *StepVector) AppendHistograms(pool *VectorPool, histogramIDs []uint64, h
 	}
 	s.HistogramIDs = append(s.HistogramIDs, histogramIDs...)
 	s.Histograms = append(s.Histograms, hs...)
+}
+
+func (s *StepVector) RemoveHistogram(index int) {
+	s.Histograms = append(s.Histograms[:index], s.Histograms[index+1:]...)
+	s.HistogramIDs = append(s.HistogramIDs[:index], s.HistogramIDs[index+1:]...)
 }


### PR DESCRIPTION
This commit adds support for all native histogram functions which currently have a sane behavior in Prometheus. These include:
* histogram_sum
* histogram_count
* histogram_fraction
* histogram_quantile

These functions should be sufficient to allow the engine to work with native histograms.