### PR TITLE
Fixing panic when histogram schema not matches

### DIFF
--- a/execution/aggregate/scalar_table.go
+++ b/execution/aggregate/scalar_table.go
@@ -152,6 +152,10 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 						histSum = h
 						return
 					}
+					// https://github.com/prometheus/prometheus/blob/57bcbf18880f7554ae34c5b341d52fc53f059a97/model/histogram/float_histogram.go#L86
+					if histSum.Schema > h.Schema {
+						return
+					}
 					histSum = histSum.Add(h)
 				},
 				ValueFunc: func() (float64, *histogram.FloatHistogram) {


### PR DESCRIPTION
Queriers Panic when histogram schema does not matches
```
goroutine 936 [running]:
github.com/prometheus/prometheus/model/histogram.(*FloatHistogram).floatBucketIterator(0xc000e3d170?, 0xc0?, 0x37f0000000000000?, 0x3)
        /go/pkg/mod/github.com/prometheus/prometheus@v0.42.0/model/histogram/float_histogram.go:699 +0x19c
github.com/prometheus/prometheus/model/histogram.(*FloatHistogram).Add(0xc000e3d170, 0xc0016866c0)
        /go/pkg/mod/github.com/prometheus/prometheus@v0.42.0/model/histogram/float_histogram.go:203 +0x8a
github.com/thanos-community/promql-engine/execution/aggregate.histogramSum({0xc000e30f00, 0x98, 0x0?})
        /go/pkg/mod/github.com/thanos-community/promql-engine@v0.0.0-20230216083447-f09127b8558c/execution/aggregate/vector_table.go:136 +0x5d
github.com/thanos-community/promql-engine/execution/aggregate.newVectorAccumulator.func1({0x0?, 0xc000a5fb30?, 0x93f08d?}, {0xc000e30f00?, 0x3?, 0xc000a5fb88?})
        /go/pkg/mod/github.com/thanos-community/promql-engine@v0.0.0-20230216083447-f09127b8558c/execution/aggregate/vector_table.go:93 +0x88
github.com/thanos-community/promql-engine/execution/aggregate.(*vectorTable).aggregate(0xc0010b8d80, 0x0?, {0x18661145d50, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, {0xc0019b8a00, ...}, ...})
        /go/pkg/mod/github.com/thanos-community/promql-engine@v0.0.0-20230216083447-f09127b8558c/execution/aggregate/vector_table.go:58 +0x83
github.com/thanos-community/promql-engine/execution/aggregate.(*aggregate).workerTask(0xc0005b6270, 0xc00123c6a4?, 0xc000602ea0?, {0x18661145d50, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, ...})
        /go/pkg/mod/github.com/thanos-community/promql-engine@v0.0.0-20230216083447-f09127b8558c/execution/aggregate/hashaggregate.go:182 +0xde
github.com/thanos-community/promql-engine/worker.(*Worker).start(0xc0010b8b10, 0xc0010b9d70?, {0x2b1d8d0?, 0xc000889020?})
        /go/pkg/mod/github.com/thanos-community/promql-engine@v0.0.0-20230216083447-f09127b8558c/worker/worker.go:74 +0xff
created by github.com/thanos-community/promql-engine/worker.Group.Start
        /go/pkg/mod/github.com/thanos-community/promql-engine@v0.0.0-20230216083447-f09127b8558c/worker/worker.go:29 +0x4b
panic: cannot merge from schema 2 to 3

goroutine 931 [running]:
github.com/prometheus/prometheus/model/histogram.(*FloatHistogram).floatBucketIterator(0xc000e438c0?, 0xc0?, 0x37f0000000000000?, 0x3)
        /go/pkg/mod/github.com/prometheus/prometheus@v0.42.0/model/histogram/float_histogram.go:699 +0x19c
github.com/prometheus/prometheus/model/histogram.(*FloatHistogram).Add(0xc000e438c0, 0xc000d2f8c0)
        /go/pkg/mod/github.com/prometheus/prometheus@v0.42.0/model/histogram/float_histogram.go:203 +0x8a
github.com/thanos-community/promql-engine/execution/aggregate.histogramSum({0xc0007b8a00, 0x98, 0x1?})
        /go/pkg/mod/github.com/thanos-community/promql-engine@v0.0.0-20230216083447-f09127b8558c/execution/aggregate/vector_table.go:136 +0x5d
github.com/thanos-community/promql-engine/execution/aggregate.newVectorAccumulator.func1({0x0?, 0x0?, 0x0?}, {0xc0007b8a00?, 0x0?, 0x0?})
        /go/pkg/mod/github.com/thanos-community/promql-engine@v0.0.0-20230216083447-f09127b8558c/execution/aggregate/vector_table.go:93 +0x88
github.com/thanos-community/promql-engine/execution/aggregate.(*vectorTable).aggregate(0xc0010b8c90, 0x0?, {0x18661134be0, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, {0xc0016ee000, ...}, ...})
        /go/pkg/mod/github.com/thanos-community/promql-engine@v0.0.0-20230216083447-f09127b8558c/execution/aggregate/vector_table.go:58 +0x83
github.com/thanos-community/promql-engine/execution/aggregate.(*aggregate).workerTask(0xc0005b6270, 0xc000c596a4?, 0xc0015a41a0?, {0x18661134be0, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, ...})
        /go/pkg/mod/github.com/thanos-community/promql-engine@v0.0.0-20230216083447-f09127b8558c/execution/aggregate/hashaggregate.go:182 +0xde
github.com/thanos-community/promql-engine/worker.(*Worker).start(0xc0010b8a20, 0xc0010b9e30?, {0x2b1d8d0?, 0xc000889020?})
        /go/pkg/mod/github.com/thanos-community/promql-engine@v0.0.0-20230216083447-f09127b8558c/worker/worker.go:74 +0xff
created by github.com/thanos-community/promql-engine/worker.Group.Start
        /go/pkg/mod/github.com/thanos-community/promql-engine@v0.0.0-20230216083447-f09127b8558c/worker/worker.go:29 +0x4b
````