### PR TITLE
Fixing index out of range error in scaler operations

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -849,6 +849,16 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			query: "time()",
 		},
 		{
+			name:  "binary operation on time function",
+			load:  "",
+			query: "time() - 20",
+		},
+		{
+			name:  "reverse binary operaton on time function",
+			load:  "",
+			query: "20 - time()",
+		},
+		{
 			name:  "empty series with func",
 			load:  "",
 			query: "sum(http_requests_total)",

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -136,7 +136,11 @@ func (o *scalarOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 			} else if !keep {
 				continue
 			}
-			step.AppendSample(o.pool, vector.SampleIDs[i], val)
+			if i >= len(vector.SampleIDs) {
+				step.AppendSample(o.pool, scalarIn[v].SampleIDs[i], val)
+			} else {
+				step.AppendSample(o.pool, vector.SampleIDs[i], val)
+			}
 		}
 		out = append(out, step)
 		o.next.GetPool().PutStepVector(vector)

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -63,7 +63,7 @@ func (o *noArgFunctionOperator) Next(_ context.Context) ([]model.StepVector, err
 		return nil, nil
 	}
 	ret := o.vectorPool.GetVectorBatch()
-	for i := 0; i < o.stepsBatch && o.currentStep <= o.maxt; i++ {
+	for i := 0; o.currentStep <= o.maxt; i++ {
 		sv := o.vectorPool.GetStepVector(o.currentStep)
 		result := o.call(FunctionArgs{
 			StepTime: o.currentStep,


### PR DESCRIPTION
Seeing following error while running example query `time()-10`

<img width="1486" alt="image" src="https://user-images.githubusercontent.com/2407900/221003846-9261bb67-354e-49e8-a4cd-8f7699607a42.png">

Also noticed time() function only return 10 data points 
<img width="1502" alt="image" src="https://user-images.githubusercontent.com/2407900/221004243-1d931643-c362-4876-b12e-4b0c032c905b.png">
