### PR TITLE
Fix scalar and noArg functions

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -363,24 +363,8 @@ loop:
 
 			// Case where Series call might return nil, but samples are present.
 			// For example scalar(http_request_total) where http_request_total has multiple values.
-			if len(resultSeries) == 0 && len(r) != 0 {
-				numSeries := 0
-				for i := range r {
-					numSeries += len(r[i].Samples)
-				}
-				series = make([]promql.Series, numSeries)
-
-				for _, vector := range r {
-					for i := range vector.Samples {
-						series[i].Points = append(series[i].Points, promql.Point{
-							T: vector.T,
-							V: vector.Samples[i],
-						})
-					}
-					q.Query.exec.GetPool().PutStepVector(vector)
-				}
-				q.Query.exec.GetPool().PutVectors(r)
-				continue
+			if len(series) == 0 && len(r) != 0 {
+				series = make([]promql.Series, len(r[0].Samples))
 			}
 
 			for _, vector := range r {

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -128,7 +128,7 @@ func (a *aggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 		}
 		for i := range a.params {
 			a.params[i] = math.NaN()
-			if i < len(args) {
+			if i < len(args) && len(args[i].Samples) > 0 {
 				a.params[i] = args[i].Samples[0]
 				a.paramOp.GetPool().PutStepVector(args[i])
 			}

--- a/execution/aggregate/vector_table.go
+++ b/execution/aggregate/vector_table.go
@@ -47,13 +47,14 @@ func newVectorizedTable(a vectorAccumulator) *vectorTable {
 }
 
 func (t *vectorTable) aggregate(_ float64, vector model.StepVector) {
+	t.timestamp = vector.T
+
 	if len(vector.SampleIDs) == 0 && len(vector.Histograms) == 0 {
 		t.hasValue = false
 		return
 	}
-
 	t.hasValue = true
-	t.timestamp = vector.T
+
 	var ok bool
 	t.value, t.histValue, ok = t.accumulator(vector.Samples, vector.Histograms)
 	if !ok {


### PR DESCRIPTION
Looking at PR #185, I noticed that the functions which produce nil labels are not properly handled by the engine. They are handled as an exception in the engine and unwinded separately. This code has a bug where it only takes the last batch that comes out of the operator.

The reason why this was not caught by tests is because our default query range is very short and is covered by a single batch of 10 steps. This PR increases the default range to help uncover the issues. It also fixes the  tests that fail due to the increased range.