### PR TITLE
engine,execution: fix aggregation issues

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -100,6 +100,30 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 		step  time.Duration
 	}{
 		{
+			name: "stddev with NaN 1",
+			load: `load 30s
+				       http_requests_total{pod="nginx-1", route="/"} NaN
+				       http_requests_total{pod="nginx-2", route="/"} 1`,
+			query: "stddev by (route) (http_requests_total)",
+		},
+		{
+			name: "stddev with NaN 2",
+			load: `load 30s
+				       http_requests_total{pod="nginx-1", route="/"} NaN
+				       http_requests_total{pod="nginx-2", route="/"} 1`,
+			query: "stddev by (pod) (http_requests_total)",
+		},
+		{
+			name: "aggregate without",
+			load: `load 30s
+				       http_requests_total{pod="nginx-1"} 1+1.1x1
+				       http_requests_total{pod="nginx-2"} 2+2.3x1`,
+			start: time.Unix(0, 0),
+			end:   time.Unix(60, 0),
+			step:  30 * time.Second,
+			query: "avg without (pod) (http_requests_total)",
+		},
+		{
 			name: "func with scalar arg that selects storage, checks whether same series handled correctly",
 			load: `load 30s
 			    thanos_cache_redis_hits_total{name="caching-bucket",service="thanos-store"} 1+1x30`,

--- a/execution/aggregate/scalar_table.go
+++ b/execution/aggregate/scalar_table.go
@@ -109,6 +109,7 @@ func hashMetric(metric labels.Labels, without bool, grouping []string, buf []byt
 	if without {
 		lb := labels.NewBuilder(metric)
 		lb.Del(grouping...)
+		lb.Del(labels.MetricName)
 		key, bytes := metric.HashWithoutLabels(buf, grouping...)
 		return key, string(bytes), lb.Labels(nil)
 	}
@@ -296,6 +297,9 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 					aux, cAux = function.KahanSumInc(delta*(v-(mean+cMean)), aux, cAux)
 				},
 				ValueFunc: func() (float64, *histogram.FloatHistogram) {
+					if count == 1 {
+						return 0, nil
+					}
 					return math.Sqrt((aux + cAux) / count), nil
 				},
 				HasValue: func() bool { return hasValue },
@@ -324,6 +328,9 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 					aux, cAux = function.KahanSumInc(delta*(v-(mean+cMean)), aux, cAux)
 				},
 				ValueFunc: func() (float64, *histogram.FloatHistogram) {
+					if count == 1 {
+						return 0, nil
+					}
 					return (aux + cAux) / count, nil
 				},
 				HasValue: func() bool { return hasValue },


### PR DESCRIPTION
Addresses #166 

Found an issue with `stddev` and `stdvar` when aggregating over a label with cardinality 1; upstream promql zeros out the first value (https://github.com/prometheus/prometheus/blob/ae72c752a175733a1150c04d68ea2d485d0a37ad/promql/engine.go#L2424).

The changes to fuzzing were just from me playing around; i can drop them from the PR if needed.