### PR TITLE
Fix distributed exec for no arg functions

### DIFF
--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -177,6 +177,8 @@ func isDistributive(expr *parser.Expr) bool {
 		if _, ok := distributiveAggregations[aggr.Op]; !ok {
 			return false
 		}
+	case *parser.Call:
+		return len(aggr.Args) > 0
 	}
 
 	return true

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -128,6 +128,21 @@ histogram_quantile(0.5, sum by (le) (dedup(
   remote(sum by (le, region) (rate(coredns_dns_request_duration_seconds_bucket[5m])))
 )))`,
 		},
+		{
+			name:     "binary expression with time",
+			expr:     `time() - max by (foo) (bar)`,
+			expected: `time() - max by (foo) (dedup(remote(max by (foo, region) (bar)), remote(max by (foo, region) (bar))))`,
+		},
+		{
+			name:     "number literal",
+			expr:     `1`,
+			expected: `1`,
+		},
+		{
+			name:     "aggregation with number literal",
+			expr:     `max(foo) - 1`,
+			expected: `max(dedup(remote(max by (region) (foo)), remote(max by (region) (foo)))) - 1`,
+		},
 	}
 
 	engines := []api.RemoteEngine{


### PR DESCRIPTION
Functions without arguments can be calculated in memory and do not need to be distributed. This commit changes the distributing optimizer to always run such functions using the local engine.