### PR TITLE
Add support for float histograms

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -3230,6 +3230,14 @@ func TestEngineRecoversFromPanic(t *testing.T) {
 
 }
 
+type histogramTestCase struct {
+	name                   string
+	query                  string
+	wantEmptyForMixedTypes bool
+}
+
+type histogramGeneratorFunc func(app storage.Appender, withMixedTypes bool) error
+
 func TestNativeHistograms(t *testing.T) {
 	opts := promql.EngineOpts{
 		Timeout:              1 * time.Hour,
@@ -3238,11 +3246,7 @@ func TestNativeHistograms(t *testing.T) {
 		EnableAtModifier:     true,
 	}
 
-	cases := []struct {
-		name                   string
-		query                  string
-		wantEmptyForMixedTypes bool
-	}{
+	cases := []histogramTestCase{
 		{
 			name:  "plain selector",
 			query: "native_histogram_series",
@@ -3319,6 +3323,15 @@ func TestNativeHistograms(t *testing.T) {
 		},
 	}
 
+	t.Run("integer_histograms", func(t *testing.T) {
+		testNativeHistograms(t, cases, opts, generateNativeHistogramSeries)
+	})
+	t.Run("float_histograms", func(t *testing.T) {
+		testNativeHistograms(t, cases, opts, generateFloatHistogramSeries)
+	})
+}
+
+func testNativeHistograms(t *testing.T, cases []histogramTestCase, opts promql.EngineOpts, generateHistograms histogramGeneratorFunc) {
 	mixedTypesOpts := []bool{false, true}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -3329,7 +3342,7 @@ func TestNativeHistograms(t *testing.T) {
 					defer test.Close()
 
 					app := test.Storage().Appender(context.TODO())
-					err = createNativeHistogramSeries(app, withMixedTypes)
+					err = generateHistograms(app, withMixedTypes)
 					testutil.Ok(t, err)
 					testutil.Ok(t, app.Commit())
 					testutil.Ok(t, test.Run())
@@ -3344,28 +3357,31 @@ func TestNativeHistograms(t *testing.T) {
 					t.Run("instant", func(t *testing.T) {
 						qry, err := engine.NewInstantQuery(test.Queryable(), nil, tc.query, time.Unix(50, 0))
 						testutil.Ok(t, err)
-						res := qry.Exec(test.Context())
-						testutil.Ok(t, res.Err)
-						newVector, err := res.Vector()
+						newResult := qry.Exec(test.Context())
+						testutil.Ok(t, newResult.Err)
+						newVector, err := newResult.Vector()
 						testutil.Ok(t, err)
 
 						promEngine := test.QueryEngine()
 						qry, err = promEngine.NewInstantQuery(test.Queryable(), nil, tc.query, time.Unix(50, 0))
 						testutil.Ok(t, err)
-						res = qry.Exec(test.Context())
-						testutil.Ok(t, res.Err)
-						oldVector, err := res.Vector()
+						promResult := qry.Exec(test.Context())
+						testutil.Ok(t, promResult.Err)
+						promVector, err := promResult.Vector()
 						testutil.Ok(t, err)
 
 						// Make sure we're not getting back empty results.
 						if withMixedTypes && tc.wantEmptyForMixedTypes {
-							testutil.Assert(t, len(oldVector) == 0)
+							testutil.Assert(t, len(promVector) == 0)
 						}
-						testutil.Equals(t, oldVector, newVector)
+
+						sortByLabels(promResult)
+						sortByLabels(newResult)
+						testutil.Equals(t, promVector, newVector)
 					})
 
 					t.Run("range", func(t *testing.T) {
-						qry, err := engine.NewRangeQuery(test.Queryable(), nil, tc.query, time.Unix(50, 0), time.Unix(60, 0), 30*time.Second)
+						qry, err := engine.NewRangeQuery(test.Queryable(), nil, tc.query, time.Unix(50, 0), time.Unix(600, 0), 30*time.Second)
 						testutil.Ok(t, err)
 						res := qry.Exec(test.Context())
 						testutil.Ok(t, res.Err)
@@ -3373,7 +3389,7 @@ func TestNativeHistograms(t *testing.T) {
 						testutil.Ok(t, err)
 
 						promEngine := test.QueryEngine()
-						qry, err = promEngine.NewRangeQuery(test.Queryable(), nil, tc.query, time.Unix(50, 0), time.Unix(60, 0), 30*time.Second)
+						qry, err = promEngine.NewRangeQuery(test.Queryable(), nil, tc.query, time.Unix(50, 0), time.Unix(600, 0), 30*time.Second)
 						testutil.Ok(t, err)
 						res = qry.Exec(test.Context())
 						testutil.Ok(t, res.Err)
@@ -3393,7 +3409,7 @@ func TestNativeHistograms(t *testing.T) {
 	}
 }
 
-func createNativeHistogramSeries(app storage.Appender, withMixedTypes bool) error {
+func generateNativeHistogramSeries(app storage.Appender, withMixedTypes bool) error {
 	lbls := []string{labels.MetricName, "native_histogram_series", "foo", "bar"}
 	h1 := tsdb.GenerateTestHistograms(100)
 	h2 := tsdb.GenerateTestHistograms(100)
@@ -3430,6 +3446,30 @@ func createNativeHistogramSeries(app storage.Appender, withMixedTypes bool) erro
 			return err
 		}
 		if _, err := app.AppendHistogram(0, labels.FromStrings(append(lbls, "h", "2")...), ts, h2[i], nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func generateFloatHistogramSeries(app storage.Appender, withMixedTypes bool) error {
+	lbls := []string{labels.MetricName, "native_histogram_series", "foo", "bar"}
+	h1 := tsdb.GenerateTestFloatHistograms(100)
+	h2 := tsdb.GenerateTestFloatHistograms(100)
+	for i := range h1 {
+		ts := time.Unix(int64(i*15), 0).UnixMilli()
+		if withMixedTypes {
+			if _, err := app.Append(0, labels.FromStrings(append(lbls, "le", "1")...), ts, float64(i)); err != nil {
+				return err
+			}
+			if _, err := app.Append(0, labels.FromStrings(append(lbls, "le", "+Inf")...), ts, float64(i*2)); err != nil {
+				return err
+			}
+		}
+		if _, err := app.AppendHistogram(0, labels.FromStrings(append(lbls, "h", "1")...), ts, nil, h1[i]); err != nil {
+			return err
+		}
+		if _, err := app.AppendHistogram(0, labels.FromStrings(append(lbls, "h", "2")...), ts, nil, h2[i]); err != nil {
 			return err
 		}
 	}

--- a/execution/aggregate/scalar_table.go
+++ b/execution/aggregate/scalar_table.go
@@ -171,6 +171,7 @@ func makeAccumulatorFunc(expr parser.ItemType) (newAccumulatorFunc, error) {
 				// Sum returns an empty result when floats are histograms are aggregated.
 				HasValue: func() bool { return hasFloatVal != (histSum != nil) },
 				Reset: func(_ float64) {
+					histSum = nil
 					hasFloatVal = false
 					value = 0
 				},

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/thanos-community/promql-engine/execution/model"
@@ -15,6 +16,7 @@ import (
 type dedupSample struct {
 	t int64
 	v float64
+	h *histogram.FloatHistogram
 }
 
 // The dedupCache is an internal cache used to deduplicate samples inside a single step vector.
@@ -66,6 +68,12 @@ func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 			d.dedupCache[outputSampleID].v = vector.Samples[i]
 		}
 
+		for i, inputSampleID := range vector.HistogramIDs {
+			outputSampleID := d.outputIndex[inputSampleID]
+			d.dedupCache[outputSampleID].t = vector.T
+			d.dedupCache[outputSampleID].h = vector.Histograms[i]
+		}
+
 		out := d.pool.GetStepVector(vector.T)
 		for outputSampleID, sample := range d.dedupCache {
 			// To avoid clearing the dedup cache for each step vector, we use the `t` field
@@ -73,7 +81,11 @@ func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 			// If the timestamp of the sample does not match the input vector timestamp, it means that
 			// the sample was added in a previous iteration and should be skipped.
 			if sample.t == vector.T {
-				out.AppendSample(d.pool, uint64(outputSampleID), sample.v)
+				if sample.h == nil {
+					out.AppendSample(d.pool, uint64(outputSampleID), sample.v)
+				} else {
+					out.AppendHistogram(d.pool, uint64(outputSampleID), sample.h)
+				}
 			}
 		}
 		result = append(result, out)

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -222,6 +222,7 @@ func (o *functionOperator) Next(ctx context.Context) ([]model.StepVector, error)
 
 		i := 0
 		for i < len(vectors[batchIndex].Samples) {
+			o.pointBuf[0].H = nil
 			o.pointBuf[0].V = vector.Samples[i]
 			result := o.call(o.newFunctionArgs(vector, batchIndex))
 

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -255,12 +255,10 @@ loop:
 		switch buf.Next() {
 		case chunkenc.ValNone:
 			break loop
-		case chunkenc.ValFloatHistogram:
-			return out, ErrNativeHistogramsUnsupported
-		case chunkenc.ValHistogram:
-			t, h := buf.AtHistogram()
+		case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
+			t, h := buf.AtFloatHistogram()
 			if t >= mint {
-				out = append(out, promql.Point{T: t, H: h.ToFloat()})
+				out = append(out, promql.Point{T: t, H: h})
 			}
 		case chunkenc.ValFloat:
 			t, v := buf.At()
@@ -276,12 +274,10 @@ loop:
 
 	// The sought sample might also be in the range.
 	switch soughtValueType {
-	case chunkenc.ValFloatHistogram:
-		return out, ErrNativeHistogramsUnsupported
-	case chunkenc.ValHistogram:
-		t, h := it.AtHistogram()
+	case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
+		t, h := it.AtFloatHistogram()
 		if t == maxt {
-			out = append(out, promql.Point{T: t, H: h.ToFloat()})
+			out = append(out, promql.Point{T: t, H: h})
 		}
 	case chunkenc.ValFloat:
 		t, v := it.At()

--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -23,8 +23,6 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
-var ErrNativeHistogramsUnsupported = errors.Newf("querying native histograms is not supported")
-
 type vectorScanner struct {
 	labels    labels.Labels
 	signature uint64
@@ -179,9 +177,7 @@ func selectPoint(it *storage.MemoizedSeriesIterator, ts, lookbackDelta, offset i
 		if it.Err() != nil {
 			return 0, 0, nil, false, it.Err()
 		}
-	case chunkenc.ValFloatHistogram:
-		return 0, 0, nil, false, ErrNativeHistogramsUnsupported
-	case chunkenc.ValHistogram:
+	case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
 		t, h = it.AtFloatHistogram()
 	case chunkenc.ValFloat:
 		t, v = it.At()
@@ -198,5 +194,6 @@ func selectPoint(it *storage.MemoizedSeriesIterator, ts, lookbackDelta, offset i
 	if value.IsStaleNaN(v) {
 		return 0, 0, nil, false, nil
 	}
+
 	return t, v, h, true, nil
 }


### PR DESCRIPTION
Float histograms are currently not handled by the engine. They are less frequently returned from storage, but they will be returned by a remote engine.

This commit adds support for querying this histogram type and extends existing tests to include queries against them.