### PR TITLE
execution: fix crash in nested unary negation

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -100,6 +100,10 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 		step  time.Duration
 	}{
 		{
+			name:  "nested unary negation",
+			query: "1/(-(2*2))",
+		},
+		{
 			name: "stddev with NaN 1",
 			load: `load 30s
 				       http_requests_total{pod="nginx-1", route="/"} NaN

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -11,7 +11,6 @@ import (
 	"gonum.org/v1/gonum/floats"
 
 	"github.com/thanos-community/promql-engine/execution/model"
-	"github.com/thanos-community/promql-engine/worker"
 )
 
 type unaryNegation struct {
@@ -19,8 +18,6 @@ type unaryNegation struct {
 	once sync.Once
 
 	series []labels.Labels
-
-	workers worker.Group
 }
 
 func (u *unaryNegation) Explain() (me string, next []model.VectorOperator) {
@@ -34,33 +31,31 @@ func NewUnaryNegation(
 	u := &unaryNegation{
 		next: next,
 	}
-
-	u.workers = worker.NewGroup(stepsBatch, u.workerTask)
 	return u, nil
 }
 
 func (u *unaryNegation) Series(ctx context.Context) ([]labels.Labels, error) {
-	var err error
-	u.once.Do(func() { err = u.loadSeries(ctx) })
-	if err != nil {
+	if err := u.loadSeries(ctx); err != nil {
 		return nil, err
 	}
 	return u.series, nil
 }
 
 func (u *unaryNegation) loadSeries(ctx context.Context) error {
-	vectorSeries, err := u.next.Series(ctx)
-	if err != nil {
-		return err
-	}
-	u.series = make([]labels.Labels, len(vectorSeries))
-	for i := range vectorSeries {
-		lbls := labels.NewBuilder(vectorSeries[i]).Del(labels.MetricName).Labels(nil)
-		u.series[i] = lbls
-	}
-
-	u.workers.Start(ctx)
-	return nil
+	var err error
+	u.once.Do(func() {
+		var series []labels.Labels
+		series, err = u.next.Series(ctx)
+		if err != nil {
+			return
+		}
+		u.series = make([]labels.Labels, len(series))
+		for i := range series {
+			lbls := labels.NewBuilder(series[i]).Del(labels.MetricName).Labels(nil)
+			u.series[i] = lbls
+		}
+	})
+	return err
 }
 
 func (u *unaryNegation) GetPool() *model.VectorPool {
@@ -81,24 +76,8 @@ func (u *unaryNegation) Next(ctx context.Context) ([]model.StepVector, error) {
 	if in == nil {
 		return nil, nil
 	}
-	for i, vector := range in {
-		if err := u.workers[i].Send(0, vector); err != nil {
-			return nil, err
-		}
-	}
-
 	for i := range in {
-		// Make sure worker finishes the job.
-		// Since it is in-place so no need another buffer.
-		if _, err := u.workers[i].GetOutput(); err != nil {
-			return nil, err
-		}
+		floats.Scale(-1, in[i].Samples)
 	}
-
 	return in, nil
-}
-
-func (u *unaryNegation) workerTask(_ int, _ float64, vector model.StepVector) model.StepVector {
-	floats.Scale(-1, vector.Samples)
-	return vector
 }


### PR DESCRIPTION
It was possible to use the workers without having started them first. This caused a crash on the new test:
```
level=error msg="runtime panic in engine" expr="1 / (-(2 * 2))" err="runtime error: invalid memory address or nil pointer dereference" stacktrace="goroutine 125 [running]:\ngithub.com/thanos-community/promql-engine/engine.recoverEngine({0x132a860, 0xc000628600}, {0x1336360, 0xc000067fc0}, 0xc00014ea40)\n\t/var/home/mhoffm/git/promql-engine/engine/engine.go:527 +0xc9\npanic({0xedbd20, 0x19fe100})\n\t/nix/store/4z6hhnxkmd34kp0i2p0a7nz7idvkc753-go-1.19.5/share/go/src/runtime/panic.go:884 +0x212\ngithub.com/thanos-community/promql-engine/worker.(*Worker).Send(0xc0008556b0, 0x0, {0x0, {0xc00003cdb0, 0x1, 0x1}, {0xc00003cdb8, 0x1, 0x1}, {0x0, ...}, ...})\n\t/var/home/mhoffm/git/promql-engine/worker/worker.go:81 +0x30\ngithub.com/thanos-community/promql-engine/execution/unary.(*unaryNegation).Next(0xc00086ea50, {0x1334668, 0xc000afe720})\n\t/var/home/mhoffm/git/promql-engine/execution/unary/unary.go:90 +0x25e\ngithub.com/thanos-community/promql-engine/execution/binary.(*scalarOperator).Next(0xc000876d00, {0x1334668, 0xc000afe720})\n\t/var/home/mhoffm/git/promql-engine/execution/binary/scalar.go:113 +0x1a2\ngithub.com/thanos-community/promql-engine/execution/step_invariant.(*stepInvariantOperator).cacheInputVector.func1()\n\t/var/home/mhoffm/git/promql-engine/execution/step_invariant/step_invariant.go:125 +0x77\nsync.(*Once).doSlow(0xc000b1f878?, 0xc000b1f868?)\n\t/nix/store/4z6hhnxkmd34kp0i2p0a7nz7idvkc753-go-1.19.5/share/go/src/sync/once.go:74 +0xc2\nsync.(*Once).Do(...)\n\t/nix/store/4z6hhnxkmd34kp0i2p0a7nz7idvkc753-go-1.19.5/share/go/src/sync/once.go:65\ngithub.com/thanos-community/promql-engine/execution/step_invariant.(*stepInvariantOperator).cacheInputVector(0x468ef1?, {0x1334668?, 0xc000afe720?})\n\t/var/home/mhoffm/git/promql-engine/execution/step_invariant/step_invariant.go:124 +0x95\ngithub.com/thanos-community/promql-engine/execution/step_invariant.(*stepInvariantOperator).Next(0xc00015e000, {0x1334668, 0xc000afe720})\n\t/var/home/mhoffm/git/promql-engine/execution/step_invariant/step_invariant.go:101 +0xaf\ngithub.com/thanos-community/promql-engine/engine.(*compatibilityQuery).Exec(0xc000afe6c0, {0x1334630, 0xc00012e000})\n\t/var/home/mhoffm/git/promql-engine/engine/engine.go:386 +0x385\ngithub.com/thanos-community/promql-engine/engine_test.TestQueriesAgainstOldEngine.func1.1.1(0xc000303a00)\n\t/var/home/mhoffm/git/promql-engine/engine/engine_test.go:1588 +0x2cc\ntesting.tRunner(0xc000303a00, 0xc000854a50)\n\t/nix/store/4z6hhnxkmd34kp0i2p0a7nz7idvkc753-go-1.19.5/share/go/src/testing/testing.go:1446 +0x10b\ncreated by testing.(*T).Run\n\t/nix/store/4z6hhnxkmd34kp0i2p0a7nz7idvkc753-go-1.19.5/share/go/src/testing/testing.go:1493 +0x35f\n"
    engine_test.go:1601: engine_test.go:1601: ""

         unexpected error: unexpected error: runtime error: invalid memory address or nil pointer dereference
```
