### PR TITLE
engine: remove timestamp function so that we fallback to promql again

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -314,8 +314,8 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 		{
 			name: "timestamp",
 			load: `load 30s
-					http_requests_total{pod="nginx-1"} 0
-					http_requests_total{pod="nginx-2"} 1`,
+					http_requests_total{pod="nginx-1"} 0+1x1
+					http_requests_total{pod="nginx-2"} 1+1x1`,
 			query: "timestamp(http_requests_total)",
 		},
 		{

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -312,13 +312,6 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			query: "atanh(http_requests_total)",
 		},
 		{
-			name: "timestamp",
-			load: `load 30s
-					http_requests_total{pod="nginx-1"} 0+1x1
-					http_requests_total{pod="nginx-2"} 1+1x1`,
-			query: "timestamp(http_requests_total)",
-		},
-		{
 			name: "rad",
 			load: `load 30s
 					http_requests_total{pod="nginx-1"} 5.5+1x15

--- a/execution/function/functions.go
+++ b/execution/function/functions.go
@@ -104,14 +104,6 @@ var Funcs = map[string]FunctionCall{
 			},
 		}
 	},
-	"timestamp": func(f FunctionArgs) promql.Sample {
-		return promql.Sample{
-			Point: promql.Point{
-				T: f.StepTime,
-				V: float64(f.Points[0].T) / 1000,
-			},
-		}
-	},
 	"pi": func(f FunctionArgs) promql.Sample {
 		return promql.Sample{
 			Point: promql.Point{


### PR DESCRIPTION
Prometheus returns the timestamp of the last sample in the lookback period, we currently only return 0 because we never pass a timestamp to the point that is passed to the function. It is not clear how to fix this since we do not save the timestamp of the last sample in the lookback period currently. Notice that prometheus returns `30` even at timestamp `90000` 

```
                    Diff:
                    --- Expected
                    +++ Actual
                    @@ -2,46 +2,46 @@
                     0 @[0]
                    -30 @[30000]
                    -30 @[60000]
                    -30 @[90000]
                    -30 @[120000]
                    -30 @[150000]
                    -30 @[180000]
                    -30 @[210000]
                    -30 @[240000]
                    -30 @[270000]
                    -30 @[300000]
                    -30 @[330000]
                    -30 @[360000]
                    -30 @[390000]
                    -30 @[420000]
                    -30 @[450000]
                    -30 @[480000]
                    -30 @[510000]
                    -30 @[540000]
                    -30 @[570000]
                    -30 @[600000]
                    -30 @[630000]
                    +0 @[30000]
                    +0 @[60000]
                    +0 @[90000]
                    +0 @[120000]
                    +0 @[150000]
                    +0 @[180000]
                    +0 @[210000]
                    +0 @[240000]
                    +0 @[270000]
                    +0 @[300000]
                    +0 @[330000]
                    +0 @[360000]
                    +0 @[390000]
                    +0 @[420000]
                    +0 @[450000]
                    +0 @[480000]
                    +0 @[510000]
                    +0 @[540000]
                    +0 @[570000]
                    +0 @[600000]
                    +0 @[630000]
                     {pod="nginx-2"} =>
                     0 @[0]
                    -30 @[30000]
                    -30 @[60000]
                    -30 @[90000]
                    -30 @[120000]
                    -30 @[150000]
                    -30 @[180000]
                    -30 @[210000]
                    -30 @[240000]
                    -30 @[270000]
                    -30 @[300000]
                    -30 @[330000]
                    -30 @[360000]
                    -30 @[390000]
                    -30 @[420000]
                    -30 @[450000]
                    -30 @[480000]
                    -30 @[510000]
                    -30 @[540000]
                    -30 @[570000]
                    -30 @[600000]
                    -30 @[630000])
                    +0 @[30000]
                    +0 @[60000]
                    +0 @[90000]
                    +0 @[120000]
                    +0 @[150000]...(output trimmed)

```
