### PR TITLE
engine: add test for binary operators with bool modifiers

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -735,11 +735,25 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			query: `foo < 10`,
 		},
 		{
+			name: "vector binary op with name < scalar and bool modifier",
+			load: `load 30s
+				foo{method="get", code="500"} 1+1x40
+				bar{method="get", code="500"} 1+1.1x30`,
+			query: `foo < bool 10`,
+		},
+		{
 			name: "vector binary op > scalar",
 			load: `load 30s
 				foo{method="get", code="500"} 1+2x40
 				bar{method="get", code="404"} 1+1x30`,
 			query: `sum(foo) by (method) > 10`,
+		},
+		{
+			name: "vector binary op > scalar and bool modifier",
+			load: `load 30s
+				foo{method="get", code="500"} 1+2x40
+				bar{method="get", code="404"} 1+1x30`,
+			query: `sum(foo) by (method) > bool 10`,
 		},
 		{
 			name: "scalar < vector binary op",

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -165,7 +165,7 @@ func (o *scalarOperator) loadSeries(ctx context.Context) error {
 	for i := range vectorSeries {
 		if vectorSeries[i] != nil {
 			lbls := vectorSeries[i]
-			if !o.opType.IsComparisonOperator() {
+			if shouldDropMetricName(o.opType, o.returnBool) {
 				lbls, _ = function.DropMetricName(lbls.Copy())
 			}
 			series[i] = lbls

--- a/execution/binary/table.go
+++ b/execution/binary/table.go
@@ -209,3 +209,12 @@ func btof(b bool) float64 {
 	}
 	return 0
 }
+
+func shouldDropMetricName(op parser.ItemType, returnBool bool) bool {
+	switch op.String() {
+	case "+", "-", "*", "/", "%", "^":
+		return true
+	}
+
+	return op.IsComparisonOperator() && returnBool
+}

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -125,7 +125,7 @@ func (o *vectorOperator) initOutputs(ctx context.Context) error {
 		includeLabels = o.matching.Include
 	}
 	keepLabels := o.matching.Card != parser.CardOneToOne
-	keepName := o.opType.IsComparisonOperator()
+	keepName := !shouldDropMetricName(o.opType, o.returnBool)
 	highCardHashes, highCardInputMap := o.hashSeries(highCardSide, keepLabels, keepName, buf)
 	lowCardHashes, lowCardInputMap := o.hashSeries(lowCardSide, keepLabels, keepName, buf)
 	output, highCardOutputIndex, lowCardOutputIndex := o.join(highCardHashes, highCardInputMap, lowCardHashes, lowCardInputMap, includeLabels)


### PR DESCRIPTION
If i read https://prometheus.io/docs/prometheus/latest/querying/operators/ correctly we drop the name label for all arithmetic operations and for comparisons that have the bool modifier set.