### PR TITLE
Fix topk aggregate

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1434,6 +1434,17 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			step:  2 * time.Second,
 		},
 		{
+			name: "topk wrapped by another aggregate",
+			load: `load 30s
+				http_requests_total{pod="nginx-1", series="1"} 1+1.1x40
+				http_requests_total{pod="nginx-2", series="1"} 2+2.3x50
+				http_requests_total{pod="nginx-4", series="2"} 5+2.4x50
+				http_requests_total{pod="nginx-5", series="2"} 8.4+2.3x50
+				http_requests_total{pod="nginx-6", series="2"} 2.3+2.3x50`,
+			query: "max(topk by (series) (2, http_requests_total))",
+			end:   time.Unix(3000, 0),
+		},
+		{
 			name: "topk on empty result",
 			load: `load 30s
 				metric_a 1+1x2`,

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -179,8 +179,8 @@ func (a *kAggregate) aggregate(t int64, result *[]model.StepVector, k int, Sampl
 		}
 	}
 
+	s := a.vectorPool.GetStepVector(t)
 	for _, h := range a.heaps {
-		s := a.vectorPool.GetStepVector(t)
 		// The heap keeps the lowest value on top, so reverse it.
 		if len(h.entries) > 1 {
 			sort.Sort(sort.Reverse(h))
@@ -189,9 +189,9 @@ func (a *kAggregate) aggregate(t int64, result *[]model.StepVector, k int, Sampl
 		for _, e := range h.entries {
 			s.AppendSample(a.vectorPool, e.sId, e.total)
 		}
-		*result = append(*result, s)
 		h.entries = h.entries[:0]
 	}
+	*result = append(*result, s)
 }
 
 type entry struct {


### PR DESCRIPTION
The topk aggregate appends one step vector per group. This causes vector steps to get misaligned and leads to panics in the engine.

This commit fixes the issue by appending results from all groups to the same step and adds a test to prevent regressions.

Fixes https://github.com/thanos-community/promql-engine/issues/178.