### PR TITLE
Add promqlsmith fuzzer

### DIFF
--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -7,19 +7,24 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/cortexproject/promqlsmith"
+	"github.com/efficientgo/core/errors"
 	"github.com/efficientgo/core/testutil"
 	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
 
 	"github.com/thanos-community/promql-engine/engine"
-	"github.com/thanos-community/promql-engine/execution/function"
+	"github.com/thanos-community/promql-engine/execution/parse"
 )
 
-func FuzzEngineQueryRangeMatrixFunctions(f *testing.F) {
+func FuzzEnginePromQLSmithRangeQuery(f *testing.F) {
 	f.Add(uint32(0), uint32(120), uint32(30), 1.0, 1.0, 1.0, 2.0, 30)
 
 	f.Fuzz(func(t *testing.T, startTS, endTS, intervalSeconds uint32, initialVal1, initialVal2, inc1, inc2 float64, stepRange int) {
@@ -32,108 +37,141 @@ func FuzzEngineQueryRangeMatrixFunctions(f *testing.F) {
 		if inc1 < 0 || inc2 < 0 || stepRange <= 0 || intervalSeconds <= 0 || endTS < startTS {
 			return
 		}
-		for funcName := range function.Funcs {
-			// Skipping multi-arg functions in fuzz test for now.
-			if len(parser.Functions[funcName].ArgTypes) != 1 || parser.Functions[funcName].ArgTypes[0] != parser.ValueTypeMatrix {
-				continue
-			}
 
-			load := fmt.Sprintf(`load 30s
+		load := fmt.Sprintf(`load 30s
 			http_requests_total{pod="nginx-1"} %.2f+%.2fx15
 			http_requests_total{pod="nginx-2"} %2.f+%.2fx21`, initialVal1, inc1, initialVal2, inc2)
 
-			opts := promql.EngineOpts{
-				Timeout:              1 * time.Hour,
-				MaxSamples:           1e10,
-				EnableNegativeOffset: true,
-				EnableAtModifier:     true,
-			}
-
-			test, err := promql.NewTest(t, load)
-			testutil.Ok(t, err)
-			defer test.Close()
-
-			testutil.Ok(t, test.Run())
-
-			start := time.Unix(int64(startTS), 0)
-			end := time.Unix(int64(endTS), 0)
-			interval := time.Duration(intervalSeconds) * time.Second
-			query := fmt.Sprintf("%s(http_requests_total[%ds])", funcName, stepRange)
-			if funcName == "vector" {
-				query = fmt.Sprintf("vector(%d)", stepRange)
-			}
-
-			newEngine := engine.New(engine.Opts{EngineOpts: opts, DisableFallback: true})
-
-			q1, err := newEngine.NewRangeQuery(test.Storage(), nil, query, start, end, interval)
-			testutil.Ok(t, err)
-			newResult := q1.Exec(context.Background())
-			testutil.Ok(t, newResult.Err)
-
-			oldEngine := promql.NewEngine(opts)
-			q2, err := oldEngine.NewRangeQuery(test.Storage(), nil, query, start, end, interval)
-			testutil.Ok(t, err)
-
-			oldResult := q2.Exec(context.Background())
-			testutil.Ok(t, oldResult.Err)
-
-			testutil.Equals(t, oldResult, newResult, "inconsistent result for "+funcName)
+		opts := promql.EngineOpts{
+			Timeout:              1 * time.Hour,
+			MaxSamples:           1e10,
+			EnableNegativeOffset: true,
+			EnableAtModifier:     true,
 		}
+
+		test, err := promql.NewTest(t, load)
+		testutil.Ok(t, err)
+		defer test.Close()
+
+		testutil.Ok(t, test.Run())
+
+		start := time.Unix(int64(startTS), 0)
+		end := time.Unix(int64(endTS), 0)
+		interval := time.Duration(intervalSeconds) * time.Second
+
+		seriesSet, err := getSeries(context.Background(), test.Storage())
+		require.NoError(t, err)
+		rnd := rand.New(rand.NewSource(time.Now().Unix()))
+		psOpts := []promqlsmith.Option{
+			promqlsmith.WithEnableOffset(true),
+			promqlsmith.WithEnableAtModifier(true),
+		}
+		ps := promqlsmith.New(rnd, seriesSet, psOpts...)
+
+		newEngine := engine.New(engine.Opts{EngineOpts: opts, DisableFallback: true})
+
+		var (
+			q1    promql.Query
+			query string
+		)
+		// Since we disabled fallback, keep trying until we find a query
+		// that can be natively executed by the engine.
+		for {
+			expr := ps.WalkRangeQuery()
+			query = expr.Pretty(0)
+			q1, err = newEngine.NewRangeQuery(test.Storage(), nil, query, start, end, interval)
+			if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) {
+				continue
+			} else {
+				break
+			}
+		}
+
+		testutil.Ok(t, err)
+		t.Log(query)
+		newResult := q1.Exec(context.Background())
+		testutil.Ok(t, newResult.Err)
+
+		oldEngine := promql.NewEngine(opts)
+		q2, err := oldEngine.NewRangeQuery(test.Storage(), nil, query, start, end, interval)
+		testutil.Ok(t, err)
+
+		oldResult := q2.Exec(context.Background())
+		testutil.Ok(t, oldResult.Err)
+
+		emptyLabelsToNil(newResult)
+		emptyLabelsToNil(oldResult)
+		testutil.WithGoCmp(comparer).Equals(t, oldResult, newResult, query)
 	})
 }
 
-func FuzzEngineInstantQueryAggregations(f *testing.F) {
+func FuzzEnginePromQLSmithInstantQuery(f *testing.F) {
 	f.Add(uint32(0), 0, math.NaN(), 1.0, 1.0, 2.0)
 
 	f.Fuzz(func(t *testing.T, ts uint32, groupingHash int, initialVal1, initialVal2, inc1, inc2 float64) {
 		if inc1 < 0 || inc2 < 0 {
 			return
 		}
-		for _, funcName := range []string{
-			"stddev", "sum", "max", "min", "avg", "group", "stdvar", "count",
-		} {
-			load := fmt.Sprintf(`load 30s
+		load := fmt.Sprintf(`load 30s
 			http_requests_total{pod="nginx-1", route="/"} %.2f+%.2fx4
 			http_requests_total{pod="nginx-2", route="/"} %2.f+%.2fx4`, initialVal1, inc1, initialVal2, inc2)
 
-			opts := promql.EngineOpts{
-				Timeout:    1 * time.Hour,
-				MaxSamples: 1e10,
-			}
-
-			test, err := promql.NewTest(t, load)
-			testutil.Ok(t, err)
-			defer test.Close()
-
-			testutil.Ok(t, test.Run())
-
-			queryTime := time.Unix(int64(ts), 0)
-
-			newEngine := engine.New(engine.Opts{EngineOpts: opts, DisableFallback: true})
-
-			var grouping string
-			switch groupingHash % 3 {
-			case 0:
-				grouping = " by (pod)"
-			case 1:
-				grouping = " without (route)"
-			default:
-			}
-			query := fmt.Sprintf("%s(http_requests_total)%s", funcName, grouping)
-			q1, err := newEngine.NewInstantQuery(test.Storage(), nil, query, queryTime)
-			testutil.Ok(t, err)
-			newResult := q1.Exec(context.Background())
-			testutil.Ok(t, newResult.Err)
-
-			oldEngine := promql.NewEngine(opts)
-			q2, err := oldEngine.NewInstantQuery(test.Storage(), nil, query, queryTime)
-			testutil.Ok(t, err)
-
-			oldResult := q2.Exec(context.Background())
-			testutil.Ok(t, oldResult.Err)
-
-			testutil.WithGoCmp(comparer).Equals(t, oldResult, newResult, query)
+		opts := promql.EngineOpts{
+			Timeout:              1 * time.Hour,
+			MaxSamples:           1e10,
+			EnableNegativeOffset: true,
+			EnableAtModifier:     true,
 		}
+
+		test, err := promql.NewTest(t, load)
+		testutil.Ok(t, err)
+		defer test.Close()
+		testutil.Ok(t, test.Run())
+
+		queryTime := time.Unix(int64(ts), 0)
+		newEngine := engine.New(engine.Opts{EngineOpts: opts, DisableFallback: true})
+
+		seriesSet, err := getSeries(context.Background(), test.Storage())
+		require.NoError(t, err)
+		rnd := rand.New(rand.NewSource(time.Now().Unix()))
+		psOpts := []promqlsmith.Option{
+			promqlsmith.WithEnableOffset(true),
+			promqlsmith.WithEnableAtModifier(true),
+		}
+		ps := promqlsmith.New(rnd, seriesSet, psOpts...)
+
+		var (
+			q1    promql.Query
+			query string
+		)
+		// Since we disabled fallback, keep trying until we find a query
+		// that can be natively execute by the engine.
+		for {
+			expr := ps.WalkInstantQuery()
+			query = expr.Pretty(0)
+			q1, err = newEngine.NewInstantQuery(test.Storage(), nil, query, queryTime)
+			if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) {
+				continue
+			} else {
+				break
+			}
+		}
+
+		testutil.Ok(t, err)
+		t.Log(query)
+		newResult := q1.Exec(context.Background())
+		testutil.Ok(t, newResult.Err)
+
+		oldEngine := promql.NewEngine(opts)
+		q2, err := oldEngine.NewInstantQuery(test.Storage(), nil, query, queryTime)
+		testutil.Ok(t, err)
+
+		oldResult := q2.Exec(context.Background())
+		testutil.Ok(t, oldResult.Err)
+
+		emptyLabelsToNil(newResult)
+		emptyLabelsToNil(oldResult)
+		testutil.WithGoCmp(comparer).Equals(t, oldResult, newResult, query)
 	})
 }
 
@@ -201,12 +239,38 @@ var comparer = cmp.Comparer(func(x, y *promql.Result) bool {
 				if xps[j].T != yps[j].T {
 					return false
 				}
-				if !compareFloats(xps[j].V, yps[i].V) {
+				if !compareFloats(xps[j].V, yps[j].V) {
 					return false
 				}
 			}
 		}
 		return true
 	}
+
+	sx, xscalar := x.Value.(promql.Scalar)
+	sy, yscalar := y.Value.(promql.Scalar)
+	if xscalar && yscalar {
+		if sx.T != sy.T {
+			return false
+		}
+		return compareFloats(sx.V, sy.V)
+	}
 	return false
 })
+
+func getSeries(ctx context.Context, q storage.Queryable) ([]labels.Labels, error) {
+	querier, err := q.Querier(ctx, 0, time.Now().Unix())
+	if err != nil {
+		return nil, err
+	}
+	res := make([]labels.Labels, 0)
+	ss := querier.Select(false, &storage.SelectHints{Func: "series"}, labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests_total"))
+	for ss.Next() {
+		lbls := ss.At().Labels()
+		res = append(res, lbls)
+	}
+	if err := ss.Err(); err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,13 @@ go 1.19
 
 require (
 	github.com/cespare/xxhash/v2 v2.2.0
+	github.com/cortexproject/promqlsmith v0.0.0-20230313010502-5c380a3b00b0
 	github.com/efficientgo/core v1.0.0-rc.2
 	github.com/go-kit/log v0.2.1
 	github.com/google/go-cmp v0.5.9
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/prometheus v0.42.0
+	github.com/stretchr/testify v1.8.2
 	go.uber.org/goleak v1.2.0
 	golang.org/x/exp v0.0.0-20230124195608-d38c7dcee874
 	gonum.org/v1/gonum v0.12.0
@@ -58,7 +60,6 @@ require (
 	github.com/prometheus/common v0.39.1-0.20230202092144-f9c1994be032 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
 	go.mongodb.org/mongo-driver v1.11.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc h1:PYXxkRUBGUMa5xgMVMDl62vEklZvKpVaxQeN9ie7Hfk=
+github.com/cortexproject/promqlsmith v0.0.0-20230313010502-5c380a3b00b0 h1:NxAuzQ8oCBUgmBTmhC4GyKk9kBl4IoDymGib+tVdqiQ=
+github.com/cortexproject/promqlsmith v0.0.0-20230313010502-5c380a3b00b0/go.mod h1:ngsF8Fu5zfL7q0TufnEd+QvomTblziwTKBRvb9kQ5Ic=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -314,8 +316,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=


### PR DESCRIPTION
This PR uses the new PromQLsmith query fuzzer to replace our old fuzzing test.

Fixes https://github.com/thanos-community/promql-engine/issues/209.

Note that the fuzzer already found some bugs at https://github.com/thanos-community/promql-engine/issues/200 but currently we don't have a way to tell the fuzzer to avoid generating such kind of queries. In this case, the CI will fail.

I am also wondering if we should have a dedicated workflow for running the fuzz test. And currently we don't have a way to collect queries bugs from our test run.