### PR TITLE
WIP: Add metrics to engine

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -147,8 +147,10 @@ func New(opts Opts) *compatibilityEngine {
 		),
 		queries: promauto.With(opts.Reg).NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "promql_engine_queries_total",
-				Help: "Number of PromQL queries.",
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      "queries_total",
+				Help:      "Number of PromQL queries.",
 			}, []string{"fallback"},
 		),
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -40,6 +40,8 @@ type engineMetrics struct {
 }
 
 const (
+	namespace    string    = "thanos"
+	subsystem    string    = "engine"
 	InstantQuery QueryType = 1
 	RangeQuery   QueryType = 2
 )
@@ -134,16 +136,14 @@ func New(opts Opts) *compatibilityEngine {
 	}
 
 	metrics := &engineMetrics{
-		currentQueries: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "thanos",
-			Subsystem: "engine",
-			Name:      "queries",
-			Help:      "The current number of queries being executed or waiting.",
-		}),
-	}
-
-	if opts.EngineOpts.Reg != nil {
-		opts.EngineOpts.Reg.MustRegister(metrics.currentQueries)
+		currentQueries: promauto.With(opts.Reg).NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      "queries",
+				Help:      "The current number of queries being executed or waiting.",
+			},
+		),
 	}
 
 	return &compatibilityEngine{


### PR DESCRIPTION
**Description**
Adds metrics to thanos promql engine.

**Implemented metrics**
* `currentQueries`: View no of queries executing through thanos promql engine.