### PR TITLE
Fix grouping by metric name

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -6,6 +6,7 @@ package engine
 import (
 	"context"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/prometheus/model/labels"
 	v1 "github.com/prometheus/prometheus/web/api/v1"
 
@@ -539,7 +540,7 @@ func containsDuplicateLabelSet(series []labels.Labels) bool {
 	seen := make(map[uint64]struct{}, len(series))
 	for i := range series {
 		buf = buf[:0]
-		h, buf = series[i].HashWithoutLabels(buf)
+		h = xxhash.Sum64(series[i].BytesWithoutLabels(buf))
 		if _, ok := seen[h]; ok {
 			return true
 		}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -540,7 +540,7 @@ func containsDuplicateLabelSet(series []labels.Labels) bool {
 	seen := make(map[uint64]struct{}, len(series))
 	for i := range series {
 		buf = buf[:0]
-		h = xxhash.Sum64(series[i].BytesWithoutLabels(buf))
+		h = xxhash.Sum64(series[i].Bytes(buf))
 		if _, ok := seen[h]; ok {
 			return true
 		}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1575,6 +1575,13 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 				http_requests_total{pod="nginx-6", series="2"} 2.3+2.3x50`,
 			query: "sort_desc(http_requests_total)",
 		},
+		{
+			name: "count by __name__ label",
+			load: `load 30s
+				foo 1+1x5
+				bar 2+2x5`,
+			query: `count by (__name__) ({__name__=~".+"})`,
+		},
 	}
 
 	disableOptimizerOpts := []bool{true, false}

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -148,6 +148,6 @@ func (d *dedupOperator) loadSeries(ctx context.Context) error {
 
 func hashSeries(hashBuf []byte, inputSeries labels.Labels) uint64 {
 	hashBuf = hashBuf[:0]
-	hash := xxhash.Sum64(inputSeries.BytesWithoutLabels(hashBuf))
+	hash := xxhash.Sum64(inputSeries.Bytes(hashBuf))
 	return hash
 }

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -147,6 +148,6 @@ func (d *dedupOperator) loadSeries(ctx context.Context) error {
 
 func hashSeries(hashBuf []byte, inputSeries labels.Labels) uint64 {
 	hashBuf = hashBuf[:0]
-	hash, _ := inputSeries.HashWithoutLabels(hashBuf)
+	hash := xxhash.Sum64(inputSeries.BytesWithoutLabels(hashBuf))
 	return hash
 }


### PR DESCRIPTION
The `labels.HashWithoutLabels` function from Prometheus does not take into account the `__name__` label and explicitly excludes it from the input into the hashing function. This causes grouping expressions by `__name__` to produce an error message in the form of:
```
vector cannot contain metrics with the same labelset.
```

It also interferes with deduplication in the distributed engine since series with different __name__ labels can be treated as duplicates of each other.

This commit replaces the use of `HashWithoutLabels` with `BytesWithoutLabels` in the places where the engine is affected.