### PR TITLE
Add label based pruning in distributed optimizer

### DIFF
--- a/execution/execution.go
+++ b/execution/execution.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/prometheus/prometheus/promql"
 
+	"github.com/thanos-community/promql-engine/execution/noop"
 	"github.com/thanos-community/promql-engine/execution/remote"
 
 	"github.com/efficientgo/core/errors"
@@ -268,6 +269,8 @@ func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.O
 		selectorOpts.LookbackDelta = 0
 		remoteExec := remote.NewExecution(qry, model.NewVectorPool(stepsBatch), &selectorOpts)
 		return exchange.NewConcurrent(remoteExec, 2), nil
+	case logicalplan.Noop:
+		return noop.NewOperator(), nil
 	default:
 		return nil, errors.Wrapf(parse.ErrNotSupportedExpr, "got: %s", e)
 	}

--- a/execution/noop/operator.go
+++ b/execution/noop/operator.go
@@ -1,0 +1,24 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package noop
+
+import (
+	"context"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/thanos-community/promql-engine/execution/model"
+)
+
+type operator struct{}
+
+func NewOperator() model.VectorOperator { return &operator{} }
+
+func (o operator) Next(ctx context.Context) ([]model.StepVector, error) { return nil, nil }
+
+func (o operator) Series(ctx context.Context) ([]labels.Labels, error) { return nil, nil }
+
+func (o operator) GetPool() *model.VectorPool { return nil }
+
+func (o operator) Explain() (me string, next []model.VectorOperator) { return "noop", nil }

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -283,7 +283,6 @@ func isDistributive(expr *parser.Expr) bool {
 }
 
 // matchesExternalLabels returns false if given matchers are not matching external labels.
-// If true, matchesExternalLabels also returns Prometheus matchers without those matching external labels.
 func matchesExternalLabelSet(expr parser.Expr, externalLabelSet []labels.Labels) bool {
 	if len(externalLabelSet) == 0 {
 		return true

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -285,6 +285,9 @@ func isDistributive(expr *parser.Expr) bool {
 // matchesExternalLabels returns false if given matchers are not matching external labels.
 // If true, matchesExternalLabels also returns Prometheus matchers without those matching external labels.
 func matchesExternalLabelSet(expr parser.Expr, externalLabelSet []labels.Labels) bool {
+	if len(externalLabelSet) == 0 {
+		return true
+	}
 	selectorSet := parser.ExtractSelectors(expr)
 	for _, selectors := range selectorSet {
 		hasMatch := false

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/thanos-community/promql-engine/api"
@@ -63,6 +64,18 @@ func (r Deduplicate) PositionRange() parser.PositionRange { return parser.Positi
 func (r Deduplicate) Type() parser.ValueType { return parser.ValueTypeMatrix }
 
 func (r Deduplicate) PromQLExpr() {}
+
+type Noop struct{}
+
+func (r Noop) String() string { return "noop" }
+
+func (r Noop) Pretty(level int) string { return r.String() }
+
+func (r Noop) PositionRange() parser.PositionRange { return parser.PositionRange{} }
+
+func (r Noop) Type() parser.ValueType { return parser.ValueTypeMatrix }
+
+func (r Noop) PromQLExpr() {}
 
 // distributiveAggregations are all PromQL aggregations which support
 // distributed execution.
@@ -163,6 +176,10 @@ func (m DistributedExecutionOptimizer) distributeQuery(expr *parser.Expr, engine
 
 	remoteQueries := make(RemoteExecutions, 0, len(engines))
 	for _, e := range engines {
+		if !matchesExternalLabelSet(*expr, e.LabelSets()) {
+			continue
+		}
+
 		if e.MaxT() < opts.Start.UnixMilli()-opts.LookbackDelta.Milliseconds() {
 			continue
 		}
@@ -180,6 +197,10 @@ func (m DistributedExecutionOptimizer) distributeQuery(expr *parser.Expr, engine
 			Query:           (*expr).String(),
 			QueryRangeStart: start,
 		})
+	}
+
+	if len(remoteQueries) == 0 {
+		return Noop{}
 	}
 
 	return Deduplicate{
@@ -245,7 +266,10 @@ func isDistributive(expr *parser.Expr) bool {
 		// Binary expressions are joins and need to be done across the entire
 		// data set. This is why we cannot push down aggregations where
 		// the operand is a binary expression.
-		return false
+		// The only exception currently is pushing down binary expressions with a constant operand.
+		lhsConstant := isNumberLiteral(aggr.LHS)
+		rhsConstant := isNumberLiteral(aggr.RHS)
+		return lhsConstant || rhsConstant
 	case *parser.AggregateExpr:
 		// Certain aggregations are currently not supported.
 		if _, ok := distributiveAggregations[aggr.Op]; !ok {
@@ -256,4 +280,49 @@ func isDistributive(expr *parser.Expr) bool {
 	}
 
 	return true
+}
+
+// matchesExternalLabels returns false if given matchers are not matching external labels.
+// If true, matchesExternalLabels also returns Prometheus matchers without those matching external labels.
+func matchesExternalLabelSet(expr parser.Expr, externalLabelSet []labels.Labels) bool {
+	selectorSet := parser.ExtractSelectors(expr)
+	for _, selectors := range selectorSet {
+		hasMatch := false
+		for _, externalLabels := range externalLabelSet {
+			hasMatch = hasMatch || matchesExternalLabels(selectors, externalLabels)
+		}
+		if !hasMatch {
+			return false
+		}
+	}
+
+	return true
+}
+
+// matchesExternalLabels returns false if given matchers are not matching external labels.
+func matchesExternalLabels(ms []*labels.Matcher, externalLabels labels.Labels) bool {
+	if len(externalLabels) == 0 {
+		return true
+	}
+
+	for _, matcher := range ms {
+		extValue := externalLabels.Get(matcher.Name)
+		if extValue != "" && !matcher.Matches(extValue) {
+			return false
+		}
+	}
+	return true
+}
+
+func isNumberLiteral(expr parser.Expr) bool {
+	if _, ok := expr.(*parser.NumberLiteral); ok {
+		return true
+	}
+
+	stepInvariant, ok := expr.(*parser.StepInvariantExpr)
+	if !ok {
+		return false
+	}
+
+	return isNumberLiteral(stepInvariant.Expr)
 }


### PR DESCRIPTION
The distributed optimizer currently creates a remote query for each available engine. This can increase latency for queries that can be scoped to a subset of engines based on the external labels announced by each engine.

This commit adds support for pruning engines based on their announced external labels. If the selectors for a query do not match any external engine, the query will not be executed at all.

This commit also modifies the distributed optimizer to distribute binary expressions where one operand is a constant value.