### PR TITLE
Add support for distributed absent

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -183,6 +183,10 @@ func TestDistributedAggregations(t *testing.T) {
 		{name: "binary aggregation", query: `sum by (region) (bar) / sum by (pod) (bar)`},
 		{name: "filtered selector interaction", query: `sum by (region) (bar{region="east"}) / sum by (region) (bar)`},
 		{name: "unsupported aggregation", query: `count_values("pod", bar)`, expectFallback: true},
+		{name: "absent_over_time for non-existing metric", query: `absent_over_time(foo[2m])`},
+		{name: "absent_over_time for existing metric", query: `absent_over_time(bar{pod="nginx-1"}[2m])`},
+		{name: "absent for non-existing metric", query: `absent(foo)`},
+		{name: "absent for existing metric", query: `absent(bar{pod="nginx-1"})`},
 	}
 
 	optimizersOpts := map[string][]logicalplan.Optimizer{

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -3040,16 +3040,15 @@ func storageWithSeries(series ...storage.Series) *storage.MockQueryable {
 		MockQuerier: &storage.MockQuerier{
 			SelectMockFunction: func(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
 				result := make([]storage.Series, 0)
+			loopSeries:
 				for _, s := range series {
-				loopMatchers:
 					for _, m := range matchers {
-						for _, l := range s.Labels() {
-							if m.Name == l.Name && m.Matches(l.Value) {
-								result = append(result, s)
-								break loopMatchers
-							}
+						lbl := s.Labels().Get(m.Name)
+						if lbl != "" && !m.Matches(lbl) {
+							continue loopSeries
 						}
 					}
+					result = append(result, s)
 				}
 				return newTestSeriesSet(result...)
 			},

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -156,7 +156,11 @@ func newRemoteAggregation(rootAggregation *parser.AggregateExpr, engines []api.R
 // For each engine which matches the time range of the query, it creates a RemoteExecution scoped to the range of the engine.
 // All remote executions are wrapped in a Deduplicate logical node to make sure that results from overlapping engines are deduplicated.
 // TODO(fpetkovski): Prune remote engines based on external labels.
-func (m DistributedExecutionOptimizer) distributeQuery(expr *parser.Expr, engines []api.RemoteEngine, opts *Opts) Deduplicate {
+func (m DistributedExecutionOptimizer) distributeQuery(expr *parser.Expr, engines []api.RemoteEngine, opts *Opts) parser.Expr {
+	if isAbsent(*expr) {
+		return m.distributeAbsent(*expr, engines, opts)
+	}
+
 	remoteQueries := make(RemoteExecutions, 0, len(engines))
 	for _, e := range engines {
 		if e.MaxT() < opts.Start.UnixMilli()-opts.LookbackDelta.Milliseconds() {
@@ -181,6 +185,37 @@ func (m DistributedExecutionOptimizer) distributeQuery(expr *parser.Expr, engine
 	return Deduplicate{
 		Expressions: remoteQueries,
 	}
+}
+
+func (m DistributedExecutionOptimizer) distributeAbsent(expr parser.Expr, engines []api.RemoteEngine, opts *Opts) parser.Expr {
+	queries := make(RemoteExecutions, 0, len(engines))
+	for i := range engines {
+		queries = append(queries, RemoteExecution{
+			Engine:          engines[i],
+			Query:           expr.String(),
+			QueryRangeStart: opts.Start,
+		})
+	}
+
+	var rootExpr parser.Expr = queries[0]
+	for i := 1; i < len(queries); i++ {
+		rootExpr = &parser.BinaryExpr{
+			Op:             parser.MUL,
+			LHS:            rootExpr,
+			RHS:            queries[i],
+			VectorMatching: &parser.VectorMatching{},
+		}
+	}
+
+	return rootExpr
+}
+
+func isAbsent(expr parser.Expr) bool {
+	call, ok := expr.(*parser.Call)
+	if !ok {
+		return false
+	}
+	return call.Func.Name == "absent" || call.Func.Name == "absent_over_time"
 }
 
 // calculateStepAlignedStart returns a start time for the query based on the

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -143,6 +143,11 @@ histogram_quantile(0.5, sum by (le) (dedup(
 			expr:     `max(foo) - 1`,
 			expected: `max(dedup(remote(max by (region) (foo)), remote(max by (region) (foo)))) - 1`,
 		},
+		{
+			name:     "absent",
+			expr:     `absent(foo)`,
+			expected: `remote(absent(foo)) * remote(absent(foo))`,
+		},
 	}
 
 	engines := []api.RemoteEngine{


### PR DESCRIPTION
The current way to distribute functions is to run them against each engine and concatenate the result.
The absent and absent_over_time functions are special in the sense that they act on the entire step vector instead of on individual series. Because of this, these two functions can currently return false positives if a series is absent in one engine but not in another.

This commit adds special handling for the two functions that is similar to how aggregations are distributed. Absent will be executed against each engine as before, but all results in the root engine will be merged with a multiplication operator. As a result, a series will be considered absent only if it is absent in all engines, which is in line with the semantics of the functions.