### PR TITLE
Add engine param to thanos engine constructor

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -73,6 +73,9 @@ type Opts struct {
 	// EnableXFunctions enables custom xRate, xIncrease and xDelta functions.
 	// This will default to false.
 	EnableXFunctions bool
+
+	// FallbackEngine
+	Engine v1.QueryEngine
 }
 
 func (o Opts) getLogicalOptimizers() []logicalplan.Optimizer {
@@ -193,8 +196,15 @@ func New(opts Opts) *compatibilityEngine {
 		),
 	}
 
+	var engine v1.QueryEngine
+	if opts.Engine == nil {
+		engine = promql.NewEngine(opts.EngineOpts)
+	} else {
+		engine = opts.Engine
+	}
+
 	return &compatibilityEngine{
-		prom: promql.NewEngine(opts.EngineOpts),
+		prom: engine,
 
 		debugWriter:       opts.DebugWriter,
 		disableFallback:   opts.DisableFallback,
@@ -208,7 +218,7 @@ func New(opts Opts) *compatibilityEngine {
 }
 
 type compatibilityEngine struct {
-	prom *promql.Engine
+	prom v1.QueryEngine
 
 	debugWriter io.Writer
 


### PR DESCRIPTION
Prometheus and Thanos engine both uses same registerer to register the metrics. A error raises when we try to register a metric multiple time in promql engine. ~To avoid them I seperated thanos promql engine metrics with prefix `compatibility_engine_`.~

Edit: Added `engine` for fallback engine in EngineOpts. If engine is not provided then creates one otherwise uses the same.
Also, change `prom` type to `v1.QueryEngine` from `*promql.Engine` in thanos `CompatibilityEngine`.

Related: thanos-io/thanos#6234