### PR TITLE
Add support for string literals and `label_join` function

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -458,7 +458,10 @@ type compatibilityQuery struct {
 
 func (q *compatibilityQuery) Exec(ctx context.Context) (ret *promql.Result) {
 	// Handle case with strings early on as this does not need us to process samples.
-	// TODO(saswatamcode): Modify models.StepVector to support all types and check during executor creation.
+	switch e := q.expr.(type) {
+	case *parser.StringLiteral:
+		return &promql.Result{Value: promql.String{V: e.Val, T: q.ts.UnixMilli()}}
+	}
 	ret = &promql.Result{
 		Value: promql.Vector{},
 	}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2623,6 +2623,42 @@ func TestInstantQuery(t *testing.T) {
 			query: "avg(http_requests_total)",
 		},
 		{
+			name: "label_join",
+			load: `load 30s
+						http_requests_total{pod="nginx-1", series="1"} 1+1.1x40
+						http_requests_total{pod="nginx-2", series="2"} 2+2.3x50
+						http_requests_total{pod="nginx-4", series="3"} 5+2.4x50`,
+			queryTime: time.Unix(160, 0),
+			query:     `label_join(http_requests_total{}, "label", "-", "pod", "series")`,
+		},
+		{
+			name: "label_join with non-existing src labels",
+			load: `load 30s
+						http_requests_total{pod="nginx-1", series="1"} 1+1.1x40
+						http_requests_total{pod="nginx-2", series="2"} 2+2.3x50
+						http_requests_total{pod="nginx-4", series="3"} 5+2.4x50`,
+			queryTime: time.Unix(160, 0),
+			query:     `label_join(http_requests_total{}, "label", "-", "test", "fake")`,
+		},
+		{
+			name: "label_join with overwrite dst label if exists",
+			load: `load 30s
+						http_requests_total{pod="nginx-1", series="1", label="test-1"} 1+1.1x40
+						http_requests_total{pod="nginx-2", series="2", label="test-2"} 2+2.3x50
+						http_requests_total{pod="nginx-4", series="3", label="test-3"} 5+2.4x50`,
+			queryTime: time.Unix(160, 0),
+			query:     `label_join(http_requests_total{}, "label", "-", "pod", "series")`,
+		},
+		{
+			name: "label_join with no src labels provided",
+			load: `load 30s
+						http_requests_total{pod="nginx-1", series="1"} 1+1.1x40
+						http_requests_total{pod="nginx-2", series="2"} 2+2.3x50
+						http_requests_total{pod="nginx-4", series="3"} 5+2.4x50`,
+			queryTime: time.Unix(160, 0),
+			query:     `label_join(http_requests_total{}, "label", "-")`,
+		},
+		{
 			name: "topk",
 			load: `load 30s
 						http_requests_total{pod="nginx-1", series="1"} 1

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2473,6 +2473,12 @@ func TestInstantQuery(t *testing.T) {
 			query:     "12 + 1",
 		},
 		{
+			name:      "string literal",
+			load:      ``,
+			queryTime: time.Unix(160, 0),
+			query:     "test-string-literal",
+		},
+		{
 			name: "increase plus offset",
 			load: `load 1s
 			http_requests_total{pod="nginx-1"} 1+1x180`,

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -159,13 +159,17 @@ func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.O
 		}
 
 		// Does not have matrix arg so create functionOperator normally.
-		nextOperators := make([]model.VectorOperator, len(e.Args))
+		nextOperators := make([]model.VectorOperator, 0, len(e.Args))
 		for i := range e.Args {
+			// Strings don't need an operator
+			if e.Args[i].Type() == parser.ValueTypeString {
+				continue
+			}
 			next, err := newOperator(e.Args[i], storage, opts, hints)
 			if err != nil {
 				return nil, err
 			}
-			nextOperators[i] = next
+			nextOperators = append(nextOperators, next)
 		}
 
 		return function.NewFunctionOperator(e, call, nextOperators, stepsBatch, opts)
@@ -181,7 +185,7 @@ func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.O
 			return nil, err
 		}
 
-		if e.Param != nil {
+		if e.Param != nil && e.Param.Type() != parser.ValueTypeString {
 			paramOp, err = newOperator(e.Param, storage, opts, hints)
 			if err != nil {
 				return nil, err
@@ -211,8 +215,7 @@ func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.O
 		return newOperator(e.Expr, storage, opts, hints)
 
 	case *parser.StringLiteral:
-		// TODO(saswatamcode): This requires separate model with strings.
-		return nil, errors.Wrapf(parse.ErrNotImplemented, "got: %s", e)
+		return nil, errors.Newf("string literals don't support operators: %s", e)
 
 	case *parser.UnaryExpr:
 		next, err := newOperator(e.Expr, storage, opts, hints)

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -214,9 +214,6 @@ func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.O
 	case *parser.ParenExpr:
 		return newOperator(e.Expr, storage, opts, hints)
 
-	case *parser.StringLiteral:
-		return nil, errors.Newf("string literals don't support operators: %s", e)
-
 	case *parser.UnaryExpr:
 		next, err := newOperator(e.Expr, storage, opts, hints)
 		if err != nil {

--- a/execution/function/functions.go
+++ b/execution/function/functions.go
@@ -199,6 +199,10 @@ var Funcs = map[string]FunctionCall{
 			F:      f.Samples[len(f.Samples)-1].F,
 		}
 	},
+	"label_join": func(f FunctionArgs) promql.Sample {
+		// This is specifically handled by functionOperator Series()
+		return promql.Sample{}
+	},
 	"present_over_time": func(f FunctionArgs) promql.Sample {
 		if len(f.Samples) == 0 {
 			return InvalidSample

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -131,10 +131,12 @@ func NewFunctionOperator(funcExpr *parser.Call, call FunctionCall, nextOps []mod
 	}
 
 	// Check selector type.
-	// TODO(saswatamcode): Add support for string and matrix.
+	// TODO(saswatamcode): Add support for matrix.
 	switch funcExpr.Args[f.vectorIndex].Type() {
 	case parser.ValueTypeVector, parser.ValueTypeScalar:
 		return f, nil
+	case parser.ValueTypeString:
+		return nil, errors.Newf("String literals can't be used as operators: %s", funcExpr.String())
 	default:
 		return nil, errors.Wrapf(parse.ErrNotImplemented, "got %s:", funcExpr.String())
 	}

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -225,8 +225,12 @@ func preprocessExprHelper(expr parser.Expr, start, end time.Time) bool {
 	case *parser.UnaryExpr:
 		return preprocessExprHelper(n.Expr, start, end)
 
-	case *parser.StringLiteral, *parser.NumberLiteral:
+	case *parser.NumberLiteral:
 		return true
+	case *parser.StringLiteral:
+		// strings should be used as fixed strings; no need
+		// to wrap under stepInvariantExpr
+		return false
 	}
 
 	panic(fmt.Sprintf("found unexpected node %#v", expr))


### PR DESCRIPTION
Promql engine does not have a support for string literals (it falls back to the old engine). Because it doesn't, functions like `label_join` and `label_replace` can't be implemented. As promql doesn't deal with strings for calculations, this PR uses the strings directly with functions. This PR adds support for label_join function. The StepInvariantExpr is no longer wrapped over the string literals (because fixed strings do not need it).

Below is the `label_join` function operator tree:

```
[*functionOperator] label_join(http_requests_total, "label", "-", "pod", "series"):
└──[*coalesce]:
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*vectorSelector] {[__name__="http_requests_total"]} 0 mod 4
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*vectorSelector] {[__name__="http_requests_total"]} 1 mod 4
   ├──[*concurrencyOperator(buff=2)]:
   │  └──[*vectorSelector] {[__name__="http_requests_total"]} 2 mod 4
   └──[*concurrencyOperator(buff=2)]:
      └──[*vectorSelector] {[__name__="http_requests_total"]} 3 mod 4
``` 