### PR TITLE
Improve query fuzzing test

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1651,6 +1651,17 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 				bar 2+2x5`,
 			query: `count by (__name__) ({__name__=~".+"})`,
 		},
+		{
+			name: "scalar with bool",
+			load: `load 30s
+				http_requests_total{pod="nginx-1", series="1"} 1+1.1x40
+				http_requests_total{pod="nginx-2", series="2"} 2+2.3x50
+				http_requests_total{pod="nginx-3", series="3"} 6+0.8x60
+				http_requests_total{pod="nginx-4", series="3"} 5+2.4x50
+				http_requests_total{pod="nginx-5", series="1"} 8.4+2.3x50
+				http_requests_total{pod="nginx-6", series="2"} 2.3+2.3x50`,
+			query: `scalar(avg_over_time({__name__="http_requests_total"}[3m])) > bool 0.9464749352949011`,
+		},
 	}
 
 	disableOptimizerOpts := []bool{true, false}
@@ -1698,7 +1709,7 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 								oldResult := q2.Exec(context.Background())
 
 								if oldResult.Err != nil {
-									testutil.NotOk(t, newResult.Err)
+									testutil.NotOk(t, newResult.Err, "expected error "+oldResult.Err.Error())
 									return
 								}
 

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -6,8 +6,10 @@ package engine_test
 import (
 	"context"
 	"fmt"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"math"
 	"math/rand"
+	"sort"
 	"testing"
 	"time"
 
@@ -26,6 +28,13 @@ import (
 	"github.com/thanos-community/promql-engine/execution/parse"
 	"github.com/thanos-community/promql-engine/logicalplan"
 )
+
+const testRuns = 100
+
+type testCase struct {
+	query          string
+	oldRes, newRes *promql.Result
+}
 
 func FuzzEnginePromQLSmithRangeQuery(f *testing.F) {
 	f.Add(uint32(0), uint32(120), uint32(30), 1.0, 1.0, 1.0, 2.0, 30)
@@ -72,40 +81,60 @@ func FuzzEnginePromQLSmithRangeQuery(f *testing.F) {
 		ps := promqlsmith.New(rnd, seriesSet, psOpts...)
 
 		newEngine := engine.New(engine.Opts{EngineOpts: opts, DisableFallback: true})
+		oldEngine := promql.NewEngine(opts)
 
 		var (
 			q1    promql.Query
 			query string
 		)
-		// Since we disabled fallback, keep trying until we find a query
-		// that can be natively executed by the engine.
-		for {
-			expr := ps.WalkRangeQuery()
-			query = expr.Pretty(0)
-			q1, err = newEngine.NewRangeQuery(test.Storage(), nil, query, start, end, interval)
-			if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) {
-				continue
-			} else {
-				break
+		cases := make([]*testCase, testRuns)
+		for i := 0; i < testRuns; i++ {
+			// Since we disabled fallback, keep trying until we find a query
+			// that can be natively executed by the engine.
+			for {
+				expr := ps.WalkRangeQuery()
+				query = expr.Pretty(0)
+				q1, err = newEngine.NewRangeQuery(test.Storage(), nil, query, start, end, interval)
+				if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) {
+					continue
+				} else {
+					break
+				}
+			}
+
+			testutil.Ok(t, err)
+			t.Logf(query)
+			newResult := q1.Exec(context.Background())
+
+			q2, err := oldEngine.NewRangeQuery(test.Storage(), nil, query, start, end, interval)
+			testutil.Ok(t, err)
+
+			oldResult := q2.Exec(context.Background())
+
+			cases[i] = &testCase{
+				query:  query,
+				newRes: newResult,
+				oldRes: oldResult,
 			}
 		}
-
-		testutil.Ok(t, err)
-		t.Log(query)
-		newResult := q1.Exec(context.Background())
-		testutil.Ok(t, newResult.Err)
-
-		oldEngine := promql.NewEngine(opts)
-		q2, err := oldEngine.NewRangeQuery(test.Storage(), nil, query, start, end, interval)
-		testutil.Ok(t, err)
-
-		oldResult := q2.Exec(context.Background())
-		testutil.Ok(t, oldResult.Err)
-
-		emptyLabelsToNil(newResult)
-		emptyLabelsToNil(oldResult)
-		testutil.WithGoCmp(comparer).Equals(t, oldResult, newResult, query)
+		validateTestCases(t, cases)
 	})
+}
+
+func validateTestCases(t *testing.T, cases []*testCase) {
+	failures := 0
+	for i, c := range cases {
+		emptyLabelsToNil(c.newRes)
+		emptyLabelsToNil(c.oldRes)
+
+		if !cmp.Equal(c.oldRes, c.newRes, comparer) {
+			t.Logf("case %d error mismatch.\n%s\nnew result: %s\nold result: %s\n", i, c.query, c.newRes.String(), c.oldRes.String())
+			failures++
+		}
+	}
+	if failures > 0 {
+		t.Fatalf("failed %d test cases", failures)
+	}
 }
 
 func FuzzEnginePromQLSmithInstantQuery(f *testing.F) {
@@ -137,6 +166,7 @@ func FuzzEnginePromQLSmithInstantQuery(f *testing.F) {
 			DisableFallback:   true,
 			LogicalOptimizers: logicalplan.AllOptimizers,
 		})
+		oldEngine := promql.NewEngine(opts)
 
 		seriesSet, err := getSeries(context.Background(), test.Storage())
 		require.NoError(t, err)
@@ -151,34 +181,37 @@ func FuzzEnginePromQLSmithInstantQuery(f *testing.F) {
 			q1    promql.Query
 			query string
 		)
-		// Since we disabled fallback, keep trying until we find a query
-		// that can be natively execute by the engine.
-		for {
-			expr := ps.WalkInstantQuery()
-			query = expr.Pretty(0)
-			q1, err = newEngine.NewInstantQuery(test.Storage(), nil, query, queryTime)
-			if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) {
-				continue
-			} else {
-				break
+		cases := make([]*testCase, testRuns)
+		for i := 0; i < testRuns; i++ {
+			// Since we disabled fallback, keep trying until we find a query
+			// that can be natively execute by the engine.
+			for {
+				expr := ps.WalkInstantQuery()
+				query = expr.Pretty(0)
+				q1, err = newEngine.NewInstantQuery(test.Storage(), nil, query, queryTime)
+				if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) {
+					continue
+				} else {
+					break
+				}
+			}
+
+			testutil.Ok(t, err)
+			t.Logf(query)
+			newResult := q1.Exec(context.Background())
+
+			q2, err := oldEngine.NewInstantQuery(test.Storage(), nil, query, queryTime)
+			testutil.Ok(t, err)
+
+			oldResult := q2.Exec(context.Background())
+
+			cases[i] = &testCase{
+				query:  query,
+				newRes: newResult,
+				oldRes: oldResult,
 			}
 		}
-
-		testutil.Ok(t, err)
-		t.Log(query)
-		newResult := q1.Exec(context.Background())
-		testutil.Ok(t, newResult.Err)
-
-		oldEngine := promql.NewEngine(opts)
-		q2, err := oldEngine.NewInstantQuery(test.Storage(), nil, query, queryTime)
-		testutil.Ok(t, err)
-
-		oldResult := q2.Exec(context.Background())
-		testutil.Ok(t, oldResult.Err)
-
-		emptyLabelsToNil(newResult)
-		emptyLabelsToNil(oldResult)
-		testutil.WithGoCmp(comparer).Equals(t, oldResult, newResult, query)
+		validateTestCases(t, cases)
 	})
 }
 
@@ -247,6 +280,7 @@ func FuzzDistributedEnginePromQLSmithRangeQuery(f *testing.F) {
 			remoteEngines = append(remoteEngines, e)
 		}
 		distEngine := engine.NewDistributedEngine(engineOpts, api.NewStaticEndpoints(remoteEngines))
+		oldEngine := promql.NewEngine(opts)
 
 		mergeStore := storage.NewFanout(nil, test.Storage(), test2.Storage())
 		seriesSet, err := getSeries(context.Background(), mergeStore)
@@ -263,34 +297,37 @@ func FuzzDistributedEnginePromQLSmithRangeQuery(f *testing.F) {
 			q1    promql.Query
 			query string
 		)
-		// Since we disabled fallback, keep trying until we find a query
-		// that can be natively execute by the engine.
-		for {
-			expr := ps.WalkRangeQuery()
-			query = expr.Pretty(0)
-			q1, err = distEngine.NewRangeQuery(mergeStore, nil, query, start, end, interval)
-			if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) {
-				continue
-			} else {
-				break
+		cases := make([]*testCase, testRuns)
+		for i := 0; i < testRuns; i++ {
+			// Since we disabled fallback, keep trying until we find a query
+			// that can be natively execute by the engine.
+			for {
+				expr := ps.WalkRangeQuery()
+				query = expr.Pretty(0)
+				q1, err = distEngine.NewRangeQuery(mergeStore, nil, query, start, end, interval)
+				if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) {
+					continue
+				} else {
+					break
+				}
+			}
+
+			testutil.Ok(t, err)
+			t.Logf(query)
+			newResult := q1.Exec(context.Background())
+
+			q2, err := oldEngine.NewRangeQuery(mergeStore, nil, query, start, end, interval)
+			testutil.Ok(t, err)
+
+			oldResult := q2.Exec(context.Background())
+
+			cases[i] = &testCase{
+				query:  query,
+				newRes: newResult,
+				oldRes: oldResult,
 			}
 		}
-
-		testutil.Ok(t, err)
-		t.Log(query)
-		newResult := q1.Exec(context.Background())
-		testutil.Ok(t, newResult.Err)
-
-		oldEngine := promql.NewEngine(opts)
-		q2, err := oldEngine.NewRangeQuery(mergeStore, nil, query, start, end, interval)
-		testutil.Ok(t, err)
-
-		oldResult := q2.Exec(context.Background())
-		testutil.Ok(t, oldResult.Err)
-
-		emptyLabelsToNil(newResult)
-		emptyLabelsToNil(oldResult)
-		testutil.WithGoCmp(comparer).Equals(t, oldResult, newResult, query)
+		validateTestCases(t, cases)
 	})
 }
 
@@ -346,6 +383,7 @@ func FuzzDistributedEnginePromQLSmithInstantQuery(f *testing.F) {
 			remoteEngines = append(remoteEngines, e)
 		}
 		distEngine := engine.NewDistributedEngine(engineOpts, api.NewStaticEndpoints(remoteEngines))
+		oldEngine := promql.NewEngine(opts)
 
 		mergeStore := storage.NewFanout(nil, test.Storage(), test2.Storage())
 		seriesSet, err := getSeries(context.Background(), mergeStore)
@@ -362,52 +400,49 @@ func FuzzDistributedEnginePromQLSmithInstantQuery(f *testing.F) {
 			q1    promql.Query
 			query string
 		)
-		// Since we disabled fallback, keep trying until we find a query
-		// that can be natively execute by the engine.
-		for {
-			expr := ps.Walk(parser.ValueTypeVector, parser.ValueTypeMatrix)
-			query = expr.Pretty(0)
-			q1, err = distEngine.NewInstantQuery(mergeStore, nil, query, queryTime)
-			if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) {
-				continue
-			} else {
-				break
+		cases := make([]*testCase, testRuns)
+		for i := 0; i < testRuns; i++ {
+			// Since we disabled fallback, keep trying until we find a query
+			// that can be natively execute by the engine.
+			for {
+				expr := ps.Walk(parser.ValueTypeVector, parser.ValueTypeMatrix)
+				query = expr.Pretty(0)
+				q1, err = distEngine.NewInstantQuery(mergeStore, nil, query, queryTime)
+				if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) {
+					continue
+				} else {
+					break
+				}
+			}
+
+			testutil.Ok(t, err)
+			t.Logf(query)
+			newResult := q1.Exec(context.Background())
+
+			q2, err := oldEngine.NewInstantQuery(mergeStore, nil, query, queryTime)
+			testutil.Ok(t, err)
+
+			oldResult := q2.Exec(context.Background())
+
+			cases[i] = &testCase{
+				query:  query,
+				newRes: newResult,
+				oldRes: oldResult,
 			}
 		}
-
-		testutil.Ok(t, err)
-		t.Log(query)
-		newResult := q1.Exec(context.Background())
-		testutil.Ok(t, newResult.Err)
-
-		oldEngine := promql.NewEngine(opts)
-		q2, err := oldEngine.NewInstantQuery(mergeStore, nil, query, queryTime)
-		testutil.Ok(t, err)
-
-		oldResult := q2.Exec(context.Background())
-		testutil.Ok(t, oldResult.Err)
-
-		emptyLabelsToNil(newResult)
-		emptyLabelsToNil(oldResult)
-		testutil.WithGoCmp(comparer).Equals(t, oldResult, newResult, query)
+		validateTestCases(t, cases)
 	})
 }
 
 var comparer = cmp.Comparer(func(x, y *promql.Result) bool {
 	compareFloats := func(l, r float64) bool {
 		const epsilon = 1e-6
-
-		if math.IsNaN(l) && math.IsNaN(r) {
-			return true
-		}
-		if math.IsNaN(l) || math.IsNaN(r) {
-			return false
-		}
-
-		return math.Abs(l-r) < epsilon
+		return cmp.Equal(l, r, cmpopts.EquateNaNs(), cmpopts.EquateApprox(0, epsilon))
 	}
 
-	if x.Err != y.Err {
+	if x.Err != nil && y.Err != nil {
+		return cmp.Equal(x.Err.Error(), y.Err.Error())
+	} else if x.Err != nil {
 		return false
 	}
 
@@ -419,6 +454,8 @@ var comparer = cmp.Comparer(func(x, y *promql.Result) bool {
 			return false
 		}
 		for i := 0; i < len(vx); i++ {
+			sort.Sort(vx[i].Metric)
+			sort.Sort(vy[i].Metric)
 			if !cmp.Equal(vx[i].Metric, vy[i].Metric) {
 				return false
 			}

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -6,7 +6,6 @@ package engine_test
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"math"
 	"math/rand"
 	"sort"
@@ -17,6 +16,7 @@ import (
 	"github.com/efficientgo/core/errors"
 	"github.com/efficientgo/core/testutil"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -457,9 +457,14 @@ var comparer = cmp.Comparer(func(x, y *promql.Result) bool {
 		if len(vx) != len(vy) {
 			return false
 		}
+		// Sort vector before comparing.
+		sort.Slice(vx, func(i, j int) bool {
+			return labels.Compare(vx[i].Metric, vx[j].Metric) < 0
+		})
+		sort.Slice(vy, func(i, j int) bool {
+			return labels.Compare(vy[i].Metric, vy[j].Metric) < 0
+		})
 		for i := 0; i < len(vx); i++ {
-			sort.Sort(vx[i].Metric)
-			sort.Sort(vy[i].Metric)
 			if !cmp.Equal(vx[i].Metric, vy[i].Metric) {
 				return false
 			}
@@ -480,6 +485,9 @@ var comparer = cmp.Comparer(func(x, y *promql.Result) bool {
 		if len(mx) != len(my) {
 			return false
 		}
+		// Sort matrix before comparing.
+		sort.Sort(mx)
+		sort.Sort(my)
 		for i := 0; i < len(mx); i++ {
 			mxs := mx[i]
 			mys := my[i]

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -33,6 +33,7 @@ const testRuns = 100
 
 type testCase struct {
 	query          string
+	load           string
 	oldRes, newRes *promql.Result
 }
 
@@ -103,7 +104,6 @@ func FuzzEnginePromQLSmithRangeQuery(f *testing.F) {
 			}
 
 			testutil.Ok(t, err)
-			t.Logf(query)
 			newResult := q1.Exec(context.Background())
 
 			q2, err := oldEngine.NewRangeQuery(test.Storage(), nil, query, start, end, interval)
@@ -115,6 +115,7 @@ func FuzzEnginePromQLSmithRangeQuery(f *testing.F) {
 				query:  query,
 				newRes: newResult,
 				oldRes: oldResult,
+				load:   load,
 			}
 		}
 		validateTestCases(t, cases)
@@ -128,7 +129,10 @@ func validateTestCases(t *testing.T, cases []*testCase) {
 		emptyLabelsToNil(c.oldRes)
 
 		if !cmp.Equal(c.oldRes, c.newRes, comparer) {
-			t.Logf("case %d error mismatch.\n%s\nnew result: %s\nold result: %s\n", i, c.query, c.newRes.String(), c.oldRes.String())
+			t.Logf(c.load)
+			t.Logf(c.query)
+
+			t.Logf("case %d error mismatch.\nnew result: %s\nold result: %s\n", i, c.newRes.String(), c.oldRes.String())
 			failures++
 		}
 	}
@@ -197,7 +201,6 @@ func FuzzEnginePromQLSmithInstantQuery(f *testing.F) {
 			}
 
 			testutil.Ok(t, err)
-			t.Logf(query)
 			newResult := q1.Exec(context.Background())
 
 			q2, err := oldEngine.NewInstantQuery(test.Storage(), nil, query, queryTime)
@@ -209,6 +212,7 @@ func FuzzEnginePromQLSmithInstantQuery(f *testing.F) {
 				query:  query,
 				newRes: newResult,
 				oldRes: oldResult,
+				load:   load,
 			}
 		}
 		validateTestCases(t, cases)
@@ -313,7 +317,6 @@ func FuzzDistributedEnginePromQLSmithRangeQuery(f *testing.F) {
 			}
 
 			testutil.Ok(t, err)
-			t.Logf(query)
 			newResult := q1.Exec(context.Background())
 
 			q2, err := oldEngine.NewRangeQuery(mergeStore, nil, query, start, end, interval)
@@ -325,6 +328,7 @@ func FuzzDistributedEnginePromQLSmithRangeQuery(f *testing.F) {
 				query:  query,
 				newRes: newResult,
 				oldRes: oldResult,
+				load:   load,
 			}
 		}
 		validateTestCases(t, cases)
@@ -416,7 +420,6 @@ func FuzzDistributedEnginePromQLSmithInstantQuery(f *testing.F) {
 			}
 
 			testutil.Ok(t, err)
-			t.Logf(query)
 			newResult := q1.Exec(context.Background())
 
 			q2, err := oldEngine.NewInstantQuery(mergeStore, nil, query, queryTime)
@@ -428,6 +431,7 @@ func FuzzDistributedEnginePromQLSmithInstantQuery(f *testing.F) {
 				query:  query,
 				newRes: newResult,
 				oldRes: oldResult,
+				load:   load,
 			}
 		}
 		validateTestCases(t, cases)

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -93,7 +93,7 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 
 		val := a.params[i]
 		if val > math.MaxInt64 || val < math.MinInt64 || math.IsNaN(val) {
-			return nil, errors.Newf("scalar value %v overflows int64", val)
+			return nil, errors.Newf("Scalar value %v overflows int64", val)
 		}
 		if int(val) == 0 {
 			return nil, nil

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -95,9 +95,6 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 		if val > math.MaxInt64 || val < math.MinInt64 || math.IsNaN(val) {
 			return nil, errors.Newf("Scalar value %v overflows int64", val)
 		}
-		if int(val) == 0 {
-			return nil, nil
-		}
 	}
 	a.paramOp.GetPool().PutVectors(args)
 
@@ -115,6 +112,11 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 
 	result := a.vectorPool.GetVectorBatch()
 	for i, vector := range in {
+		// Skip steps where the argument is less than or equal to 0.
+		if int(a.params[i]) <= 0 {
+			result = append(result, a.GetPool().GetStepVector(vector.T))
+			continue
+		}
 		a.aggregate(vector.T, &result, int(a.params[i]), vector.SampleIDs, vector.Samples)
 		a.next.GetPool().PutStepVector(vector)
 	}

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -179,7 +179,7 @@ func (o *vectorOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 		return nil, rerr
 	}
 	if lerr != nil {
-		return nil, rerr
+		return nil, lerr
 	}
 
 	// TODO(fpetkovski): When one operator becomes empty,


### PR DESCRIPTION
Now the query fuzz test just executes once, which is bad in terms of test coverage as it might not execute enough interesting queries for us.

Fixes #237

This pr improves the existing query fuzzing test by:
1. Better test case result collection and display
2. Run fuzzing test for 100 times each