### PR TITLE
Revert workaround for vector-selector selectPoint 

### DIFF
--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -177,12 +177,8 @@ func selectPoint(it *storage.MemoizedSeriesIterator, ts, lookbackDelta, offset i
 		if it.Err() != nil {
 			return 0, 0, nil, false, it.Err()
 		}
-	case chunkenc.ValFloatHistogram:
+	case chunkenc.ValFloatHistogram, chunkenc.ValHistogram:
 		t, fh = it.AtFloatHistogram()
-	case chunkenc.ValHistogram:
-		var h *histogram.Histogram
-		t, h = it.AtHistogram()
-		fh = h.ToFloat()
 	case chunkenc.ValFloat:
 		t, v = it.At()
 	default:


### PR DESCRIPTION
In this PR we revert an unnecessary fix for the vector `selectPoint` fn, which introduced a performance regression for vector select and was part of https://github.com/thanos-community/promql-engine/pull/227. It lead to an additional conversion for a already decoded histogram to float histogram, while before it was a direct decoding to a float histogram.

![image (9)](https://user-images.githubusercontent.com/4246554/231754816-38895829-0b87-4220-bacd-0d34fa4a7202.png)


 