### PR TITLE
Allow Engines method to take additional parameters

### DIFF
--- a/api/remote.go
+++ b/api/remote.go
@@ -10,8 +10,16 @@ import (
 	"github.com/prometheus/prometheus/promql"
 )
 
+type Opts struct {
+	Query         string
+	Start         time.Time
+	End           time.Time
+	Step          time.Duration
+	LookbackDelta time.Duration
+}
+
 type RemoteEndpoints interface {
-	Engines() []RemoteEngine
+	Engines(opts *Opts) []RemoteEngine
 }
 
 type RemoteEngine interface {
@@ -25,7 +33,7 @@ type staticEndpoints struct {
 	engines []RemoteEngine
 }
 
-func (m staticEndpoints) Engines() []RemoteEngine {
+func (m staticEndpoints) Engines(opts *Opts) []RemoteEngine {
 	return m.engines
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -256,6 +256,7 @@ func (e *compatibilityEngine) NewInstantQuery(q storage.Queryable, opts *promql.
 	resultSort := newResultSort(expr)
 
 	lplan := logicalplan.New(expr, &logicalplan.Opts{
+		Query:         qs,
 		Start:         ts,
 		End:           ts,
 		Step:          1,
@@ -307,6 +308,7 @@ func (e *compatibilityEngine) NewRangeQuery(q storage.Queryable, opts *promql.Qu
 	}
 
 	lplan := logicalplan.New(expr, &logicalplan.Opts{
+		Query:         qs,
 		Start:         start,
 		End:           end,
 		Step:          step,

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -97,7 +97,13 @@ type DistributedExecutionOptimizer struct {
 }
 
 func (m DistributedExecutionOptimizer) Optimize(plan parser.Expr, opts *Opts) parser.Expr {
-	engines := m.Endpoints.Engines()
+	engines := m.Endpoints.Engines(&api.Opts{
+		Query:         opts.Query,
+		Start:         opts.Start,
+		End:           opts.End,
+		Step:          opts.Step,
+		LookbackDelta: opts.LookbackDelta,
+	})
 	traverseBottomUp(nil, &plan, func(parent, current *parser.Expr) (stop bool) {
 		// If the current operation is not distributive, stop the traversal.
 		if !isDistributive(current) {

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -203,7 +203,7 @@ remote(sum by (pod, region) (rate(http_requests_total[2m]) * 60))))`,
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan := New(expr, &Opts{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
+			plan := New(expr, &Opts{Query: tcase.expr, Start: time.Unix(0, 0), End: time.Unix(0, 0)})
 			optimizedPlan := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
 			testutil.Equals(t, expectedPlan, optimizedPlan.Expr().String())

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -24,6 +24,7 @@ var DefaultOptimizers = []Optimizer{
 }
 
 type Opts struct {
+	Query         string
 	Start         time.Time
 	End           time.Time
 	Step          time.Duration

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -86,7 +86,7 @@ func TestDefaultOptimizers(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan := New(expr, &Opts{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
+			plan := New(expr, &Opts{Query: tcase.expr, Start: time.Unix(0, 0), End: time.Unix(0, 0)})
 			optimizedPlan := plan.Optimize(DefaultOptimizers)
 			expectedPlan := strings.Trim(spaces.ReplaceAllString(tcase.expected, " "), " ")
 			testutil.Equals(t, expectedPlan, optimizedPlan.Expr().String())
@@ -128,7 +128,7 @@ func TestMatcherPropagation(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan := New(expr, &Opts{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
+			plan := New(expr, &Opts{Query: tcase.expr, Start: time.Unix(0, 0), End: time.Unix(0, 0)})
 			optimizedPlan := plan.Optimize(optimizers)
 			expectedPlan := strings.Trim(spaces.ReplaceAllString(tcase.expected, " "), " ")
 			testutil.Equals(t, expectedPlan, optimizedPlan.Expr().String())


### PR DESCRIPTION
This allows `RemoteEndpoints` implementation to use different engines based on the query itself.
For example, in my usecase I will select different engines based on query, start, end and lookback delta value.