### PR TITLE
distribute: Add offset to engines to account for range selectors

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -83,26 +83,23 @@ func TestDistributedAggregations(t *testing.T) {
 	}{
 		{
 			name: "base case",
-			seriesSets: []partition{
-				{
-					extLset: []labels.Labels{labels.FromStrings("zone", "east-1")},
-					series: []*mockSeries{
-						newMockSeries(makeSeries("east-1", "nginx-1"), []int64{30, 60, 90, 120}, []float64{2, 3, 4, 5}),
-						newMockSeries(makeSeries("east-1", "nginx-2"), []int64{30, 60, 90, 120}, []float64{3, 4, 5, 6}),
-					},
+			seriesSets: []partition{{
+				extLset: []labels.Labels{labels.FromStrings("zone", "east-1")},
+				series: []*mockSeries{
+					newMockSeries(makeSeries("east-1", "nginx-1"), []int64{30, 60, 90, 120}, []float64{2, 3, 4, 5}),
+					newMockSeries(makeSeries("east-1", "nginx-2"), []int64{30, 60, 90, 120}, []float64{3, 4, 5, 6}),
 				},
-				{
-					extLset: []labels.Labels{
-						labels.FromStrings("zone", "west-1"),
-						labels.FromStrings("zone", "west-2"),
-					},
-					series: []*mockSeries{
-						newMockSeries(makeSeries("west-1", "nginx-1"), []int64{30, 60, 90, 120}, []float64{4, 5, 6, 7}),
-						newMockSeries(makeSeries("west-1", "nginx-2"), []int64{30, 60, 90, 120}, []float64{5, 6, 7, 8}),
-						newMockSeries(makeSeries("west-2", "nginx-1"), []int64{30, 60, 90, 120}, []float64{6, 7, 8, 9}),
-					},
+			}, {
+				extLset: []labels.Labels{
+					labels.FromStrings("zone", "west-1"),
+					labels.FromStrings("zone", "west-2"),
 				},
-			},
+				series: []*mockSeries{
+					newMockSeries(makeSeries("west-1", "nginx-1"), []int64{30, 60, 90, 120}, []float64{4, 5, 6, 7}),
+					newMockSeries(makeSeries("west-1", "nginx-2"), []int64{30, 60, 90, 120}, []float64{5, 6, 7, 8}),
+					newMockSeries(makeSeries("west-2", "nginx-1"), []int64{30, 60, 90, 120}, []float64{6, 7, 8, 9}),
+				},
+			}},
 			timeOverlap: partition{
 				extLset: []labels.Labels{
 					labels.FromStrings("zone", "east-1"),
@@ -111,6 +108,8 @@ func TestDistributedAggregations(t *testing.T) {
 				},
 				series: []*mockSeries{
 					newMockSeries(makeSeries("east-1", "nginx-1"), []int64{30, 60}, []float64{2, 3}),
+					newMockSeries(makeSeries("east-1", "nginx-2"), []int64{30, 60}, []float64{3, 4}),
+					newMockSeries(makeSeries("west-1", "nginx-1"), []int64{30, 60}, []float64{4, 5}),
 					newMockSeries(makeSeries("west-1", "nginx-2"), []int64{30, 60}, []float64{5, 6}),
 					newMockSeries(makeSeries("west-2", "nginx-1"), []int64{30, 60}, []float64{6, 7}),
 				},
@@ -119,17 +118,15 @@ func TestDistributedAggregations(t *testing.T) {
 		{
 			// Repro for https://github.com/thanos-community/promql-engine/issues/187.
 			name: "series with different ranges in a newer engine",
-			seriesSets: []partition{
-				{
-					extLset: []labels.Labels{labels.FromStrings("zone", "east-1")},
-					series: []*mockSeries{
-						newMockSeries(makeSeries("east-1", "nginx-1"), []int64{60, 90, 120}, []float64{3, 4, 5}),
-						newMockSeries(makeSeries("east-2", "nginx-1"), []int64{30, 60, 90, 120}, []float64{3, 4, 5, 6}),
-					},
-				},
+			seriesSets: []partition{{
+				extLset: []labels.Labels{labels.FromStrings("zone", "east-1"), labels.FromStrings("zone", "east-1")},
+				series: []*mockSeries{
+					newMockSeries(makeSeries("east-1", "nginx-1"), []int64{60, 90, 120}, []float64{3, 4, 5}),
+					newMockSeries(makeSeries("east-2", "nginx-1"), []int64{30, 60, 90, 120}, []float64{3, 4, 5, 6}),
+				}},
 			},
 			timeOverlap: partition{
-				extLset: []labels.Labels{labels.FromStrings("zone", "east-1"), labels.FromStrings("zone", "west-1")},
+				extLset: []labels.Labels{labels.FromStrings("zone", "east-1"), labels.FromStrings("zone", "east-2")},
 				series: []*mockSeries{
 					newMockSeries(makeSeries("east-1", "nginx-1"), []int64{30, 60}, []float64{2, 3}),
 					newMockSeries(makeSeries("east-2", "nginx-1"), []int64{30, 60}, []float64{3, 4}),
@@ -138,31 +135,65 @@ func TestDistributedAggregations(t *testing.T) {
 		},
 		{
 			name: "verify double lookback is not applied",
-			seriesSets: []partition{
-				{
-					extLset: []labels.Labels{labels.FromStrings("zone", "east-2")},
-					series: []*mockSeries{
-						newMockSeries(makeSeries("east-2", "nginx-1"), []int64{30, 60, 90, 120}, []float64{3, 4, 5, 6}),
-					},
+			seriesSets: []partition{{
+				extLset: []labels.Labels{labels.FromStrings("zone", "east-2")},
+				series: []*mockSeries{
+					newMockSeries(makeSeries("east-2", "nginx-1"), []int64{30, 60, 90, 120}, []float64{3, 4, 5, 6}),
+				}},
+			},
+			timeOverlap: partition{
+				extLset: []labels.Labels{labels.FromStrings("zone", "east-2")},
+				series: []*mockSeries{
+					newMockSeries(makeSeries("east-2", "nginx-1"), []int64{30, 60}, []float64{3, 4}),
 				},
 			},
 			rangeEnd: time.Unix(15000, 0),
 		},
 		{
 			name: "count by __name__ label",
-			seriesSets: []partition{
-				{
-					series: []*mockSeries{
-						newMockSeries(makeSeriesWithName("foo", "east-2", "nginx-1"), []int64{30, 60, 90, 120}, []float64{3, 4, 5, 6}),
-						newMockSeries(makeSeriesWithName("bar", "east-2", "nginx-1"), []int64{30, 60, 90, 120}, []float64{3, 4, 5, 6}),
-					},
+			seriesSets: []partition{{
+				extLset: []labels.Labels{labels.FromStrings("zone", "east-2")},
+				series: []*mockSeries{
+					newMockSeries(makeSeriesWithName("foo", "east-2", "nginx-1"), []int64{30, 60, 90, 120}, []float64{3, 4, 5, 6}),
+					newMockSeries(makeSeriesWithName("bar", "east-2", "nginx-1"), []int64{30, 60, 90, 120}, []float64{3, 4, 5, 6}),
 				},
-				{
-					series: []*mockSeries{
-						newMockSeries(makeSeriesWithName("xyz", "east-2", "nginx-1"), []int64{30, 60, 90, 120}, []float64{3, 4, 5, 6}),
-					},
+			}, {
+				extLset: []labels.Labels{labels.FromStrings("zone", "east-2"), labels.FromStrings("zone", "west-1")},
+				series: []*mockSeries{
+					newMockSeries(makeSeriesWithName("xyz", "east-2", "nginx-1"), []int64{30, 60, 90, 120}, []float64{3, 4, 5, 6}),
+				},
+			}},
+			timeOverlap: partition{
+				series: []*mockSeries{
+					newMockSeries(makeSeriesWithName("foo", "east-2", "nginx-1"), []int64{30, 60}, []float64{3, 4}),
+					newMockSeries(makeSeriesWithName("bar", "east-2", "nginx-1"), []int64{30, 60}, []float64{3, 4}),
+					newMockSeries(makeSeriesWithName("xyz", "east-2", "nginx-1"), []int64{30, 60}, []float64{3, 4}),
 				},
 			},
+		},
+		{
+			name: "engines with different retentions",
+			seriesSets: []partition{{
+				extLset: []labels.Labels{labels.FromStrings("zone", "us-east1")},
+				series: []*mockSeries{
+					newMockSeries(makeSeries("us-east1", "nginx-1"), []int64{30, 60, 90, 120, 150}, []float64{3, 4, 5, 6, 9}),
+				}}, {
+				extLset: []labels.Labels{labels.FromStrings("zone", "us-east2")},
+				series: []*mockSeries{
+					newMockSeries(makeSeries("us-east2", "nginx-2"), []int64{90, 120, 150}, []float64{7, 9, 11}),
+				},
+			}},
+			timeOverlap: partition{
+				extLset: []labels.Labels{
+					labels.FromStrings("zone", "us-east1"),
+					labels.FromStrings("zone", "us-east2"),
+				},
+				series: []*mockSeries{
+					newMockSeries(makeSeries("us-east1", "nginx-1"), []int64{30, 60, 90}, []float64{3, 4, 5}),
+					newMockSeries(makeSeries("us-east2", "nginx-2"), []int64{30, 60, 90, 120}, []float64{2, 6, 7, 9}),
+				},
+			},
+			rangeEnd: time.Unix(180, 0),
 		},
 	}
 
@@ -181,10 +212,7 @@ func TestDistributedAggregations(t *testing.T) {
 		{name: "label based pruning with no match", query: `sum by (pod) (bar{zone="north-2"})`},
 		{name: "label based pruning with one match", query: `sum by (pod) (bar{zone="east-1"})`},
 		{name: "double aggregation", query: `max by (pod) (sum by (pod) (bar))`},
-		// TODO(fpetkovski): This query fails because the range selector is longer than the
-		// retention of one engine. Uncomment the test once the issue is fixed.
-		// https://github.com/thanos-community/promql-engine/issues/195
-		// {name: "aggregation with function operand", query: `sum by (pod) (rate(bar[1m]))`},
+		{name: "aggregation with function operand", query: `sum by (pod) (rate(bar[1m]))`},
 		{name: "binary expression with constant operand", query: `sum by (region) (bar * 60)`},
 		{name: "binary aggregation", query: `sum by (region) (bar) / sum by (pod) (bar)`},
 		{name: "filtered selector interaction", query: `sum by (region) (bar{region="east"}) / sum by (region) (bar)`},

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -3905,7 +3905,7 @@ func (m *mockIterator) Next() chunkenc.ValueType {
 func (m *mockIterator) Seek(t int64) chunkenc.ValueType {
 	if m.i > -1 && m.i < len(m.timestamps) {
 		currentTS := m.timestamps[m.i]
-		if currentTS > t {
+		if currentTS >= t {
 			return chunkenc.ValFloat
 		}
 	}

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -275,7 +275,7 @@ func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.O
 		// We need to set the lookback for the selector to 0 since the remote query already applies one lookback.
 		selectorOpts := *opts
 		selectorOpts.LookbackDelta = 0
-		remoteExec := remote.NewExecution(qry, model.NewVectorPool(stepsBatch), &selectorOpts)
+		remoteExec := remote.NewExecution(qry, model.NewVectorPool(stepsBatch), e.QueryRangeStart, &selectorOpts)
 		return exchange.NewConcurrent(remoteExec, 2), nil
 	case logicalplan.Noop:
 		return noop.NewOperator(), nil

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -18,19 +19,21 @@ import (
 )
 
 type Execution struct {
-	storage        *storageAdapter
-	query          promql.Query
-	opts           *query.Options
-	vectorSelector model.VectorOperator
+	storage         *storageAdapter
+	query           promql.Query
+	opts            *query.Options
+	queryRangeStart time.Time
+	vectorSelector  model.VectorOperator
 }
 
-func NewExecution(query promql.Query, pool *model.VectorPool, opts *query.Options) *Execution {
+func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart time.Time, opts *query.Options) *Execution {
 	storage := newStorageFromQuery(query, opts)
 	return &Execution{
-		storage:        storage,
-		query:          query,
-		opts:           opts,
-		vectorSelector: scan.NewVectorSelector(pool, storage, opts, 0, 0, 1),
+		storage:         storage,
+		query:           query,
+		opts:            opts,
+		queryRangeStart: queryRangeStart,
+		vectorSelector:  scan.NewVectorSelector(pool, storage, opts, 0, 0, 1),
 	}
 }
 

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -4,6 +4,7 @@
 package logicalplan
 
 import (
+	"math"
 	"regexp"
 	"testing"
 	"time"
@@ -180,15 +181,15 @@ remote(sum by (pod, region) (rate(http_requests_total[2m]) * 60))))`,
 			expected: `sum by (pod) (noop)`,
 		},
 		{
-			name:     "label based pruning with grouping matches no engines",
+			name:     "label based pruning with grouping matches single engine",
 			expr:     `sum by (pod) (rate(http_requests_total{region="south"}[2m]))`,
 			expected: `sum by (pod) (dedup(remote(sum by (pod, region) (rate(http_requests_total{region="south"}[2m])))))`,
 		},
 	}
 
 	engines := []api.RemoteEngine{
-		newEngineMock(1, []labels.Labels{labels.FromStrings("region", "east"), labels.FromStrings("region", "south")}),
-		newEngineMock(2, []labels.Labels{labels.FromStrings("region", "west")}),
+		newEngineMock(math.MinInt64, math.MinInt64, []labels.Labels{labels.FromStrings("region", "east"), labels.FromStrings("region", "south")}),
+		newEngineMock(math.MinInt64, math.MinInt64, []labels.Labels{labels.FromStrings("region", "west")}),
 	}
 	optimizers := []Optimizer{DistributedExecutionOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 	replacements := map[string]*regexp.Regexp{
@@ -203,6 +204,109 @@ remote(sum by (pod, region) (rate(http_requests_total[2m]) * 60))))`,
 			testutil.Ok(t, err)
 
 			plan := New(expr, &Opts{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
+			optimizedPlan := plan.Optimize(optimizers)
+			expectedPlan := cleanUp(replacements, tcase.expected)
+			testutil.Equals(t, expectedPlan, optimizedPlan.Expr().String())
+		})
+	}
+}
+
+type engineOpts struct {
+	minTime time.Time
+	maxTime time.Time
+}
+
+func (o engineOpts) mint() int64 {
+	return o.minTime.UnixMilli()
+}
+
+func (o engineOpts) maxt() int64 {
+	return o.maxTime.UnixMilli()
+}
+
+func TestDistributedExecutionWithLongSelectorRanges(t *testing.T) {
+	replacements := map[string]*regexp.Regexp{
+		" ": spaces,
+		"(": openParenthesis,
+		")": closedParenthesis,
+	}
+
+	sixHours := 6 * time.Hour
+	eightHours := 8 * time.Hour
+	twelveHours := 12 * time.Hour
+
+	queryStart := time.Unix(0, 0)
+	queryEnd := time.Unix(0, 0).Add(twelveHours)
+	queryStep := time.Minute
+
+	cases := []struct {
+		name             string
+		expr             string
+		expected         string
+		firstEngineOpts  engineOpts
+		secondEngineOpts engineOpts
+	}{
+		{
+			name: "sum over 5m adds a 5 minute offset to latest engine",
+			firstEngineOpts: engineOpts{
+				minTime: queryStart,
+				maxTime: time.Unix(0, 0).Add(eightHours),
+			},
+			secondEngineOpts: engineOpts{
+				minTime: time.Unix(0, 0).Add(sixHours),
+				maxTime: queryEnd,
+			},
+			expr: `sum_over_time(metric[5m])`,
+			expected: `
+dedup(
+  remote(sum_over_time(metric[5m])),
+  remote(sum_over_time(metric[5m])) [1970-01-01 06:05:00 +0000 UTC]
+)`,
+		},
+		{
+			name: "sum over 2h adds a 2 hour offset to latest engine",
+			firstEngineOpts: engineOpts{
+				minTime: queryStart,
+				maxTime: time.Unix(0, 0).Add(eightHours),
+			},
+			secondEngineOpts: engineOpts{
+				minTime: time.Unix(0, 0).Add(sixHours),
+				maxTime: queryEnd,
+			},
+			expr: `sum_over_time(metric[2h])`,
+			expected: `
+dedup(
+  remote(sum_over_time(metric[2h])),
+  remote(sum_over_time(metric[2h])) [1970-01-01 08:00:00 +0000 UTC]
+)`,
+		},
+		{
+			name: "sum over 3h does not distribute the query due to insufficient engine overlap",
+			firstEngineOpts: engineOpts{
+				minTime: queryStart,
+				maxTime: time.Unix(0, 0).Add(eightHours),
+			},
+			secondEngineOpts: engineOpts{
+				minTime: time.Unix(0, 0).Add(sixHours),
+				maxTime: queryEnd,
+			},
+			expr:     `sum_over_time(metric[3h])`,
+			expected: `sum_over_time(metric[3h])`,
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.name, func(t *testing.T) {
+			engines := []api.RemoteEngine{
+				newEngineMock(tcase.firstEngineOpts.mint(), tcase.firstEngineOpts.maxt(), []labels.Labels{labels.FromStrings("region", "east")}),
+				newEngineMock(tcase.secondEngineOpts.mint(), tcase.secondEngineOpts.maxt(), []labels.Labels{labels.FromStrings("region", "east")}),
+			}
+			optimizers := []Optimizer{DistributedExecutionOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
+
+			expr, err := parser.ParseExpr(tcase.expr)
+			testutil.Ok(t, err)
+
+			plan := New(expr, &Opts{Start: queryStart, End: queryEnd, Step: queryStep})
 			optimizedPlan := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
 			testutil.Equals(t, expectedPlan, optimizedPlan.Expr().String())
@@ -229,6 +333,6 @@ func (e engineMock) LabelSets() []labels.Labels {
 	return e.labelSets
 }
 
-func newEngineMock(maxT int64, labelSets []labels.Labels) *engineMock {
-	return &engineMock{maxT: maxT, labelSets: labelSets}
+func newEngineMock(mint, maxt int64, labelSets []labels.Labels) *engineMock {
+	return &engineMock{minT: mint, maxT: maxt, labelSets: labelSets}
 }

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -30,6 +30,10 @@ type Opts struct {
 	LookbackDelta time.Duration
 }
 
+func (o Opts) IsInstantQuery() bool {
+	return o.Start == o.End
+}
+
 type Plan interface {
 	Optimize([]Optimizer) Plan
 	Expr() parser.Expr
@@ -103,7 +107,7 @@ func traverseBottomUp(parent *parser.Expr, current *parser.Expr, transform func(
 	case *parser.VectorSelector:
 		return transform(parent, current)
 	case *parser.MatrixSelector:
-		return transform(parent, &node.VectorSelector)
+		return transform(current, &node.VectorSelector)
 	case *parser.AggregateExpr:
 		if stop := traverseBottomUp(current, &node.Expr, transform); stop {
 			return stop


### PR DESCRIPTION
Range selectors in PromQL need to select points from before the start of the range query. When running the distributed optimizer, certain engines might not have sufficient range in the past to correctly calculate the result for certain steps in the range.

To avoid returning incorrect results, this commit calculates the offset that needs to be added to the beginning of a query for each individual remote engine. This PR also adds detection for whether a sufficient time-based overlap exists between engines for queries to be safely distributed. If the overlap is not sufficient, the distributed optimizer will not modify the query and the engine will execute it in memory.

This addresses https://github.com/thanos-community/promql-engine/issues/195. Ideally we want to remove the fallback in the future and figure out how to distribute these queries as well.