### PR TITLE
engine: add ExplainableQuery interface

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -331,6 +331,15 @@ func (e *compatibilityEngine) NewRangeQuery(ctx context.Context, q storage.Query
 	}, nil
 }
 
+type ExplainableQuery interface {
+	promql.Query
+
+	Explain() string
+	Profile()
+}
+
+var _ ExplainableQuery = &compatibilityQuery{}
+
 type Query struct {
 	exec model.VectorOperator
 	opts *promql.QueryOpts


### PR DESCRIPTION
Add `ExplainableQuery` interface which is like a `promql.Query` but allows accessing `Explain()` and `Profile()` methods. It will be used to call those methods during query execution - idea is to try to cast a `promql.Query` into `ExplainableQuery` and then expose Explain() later on through the UI.