### PR TITLE
Revert sampleRing iterator bug workaround

### DIFF
--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -367,6 +367,9 @@ loop:
 			break loop
 		case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
 			t, fh := buf.AtFloatHistogram()
+			if value.IsStaleNaN(fh.Sum) {
+				continue loop
+			}
 			if t >= mint {
 				out = append(out, promql.Sample{T: t, H: fh})
 			}
@@ -393,7 +396,7 @@ loop:
 	switch soughtValueType {
 	case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
 		t, fh := it.AtFloatHistogram()
-		if t == maxt {
+		if t == maxt && !value.IsStaleNaN(fh.Sum) {
 			out = append(out, promql.Sample{T: t, H: fh})
 		}
 	case chunkenc.ValFloat:

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -275,15 +275,7 @@ loop:
 		switch buf.Next() {
 		case chunkenc.ValNone:
 			break loop
-		case chunkenc.ValHistogram:
-			t, h := buf.AtHistogram()
-			if value.IsStaleNaN(h.Sum) {
-				continue loop
-			}
-			if t >= mint {
-				out = append(out, promql.Sample{T: t, H: h.ToFloat()})
-			}
-		case chunkenc.ValFloatHistogram:
+		case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
 			t, fh := buf.AtFloatHistogram()
 			if value.IsStaleNaN(fh.Sum) {
 				continue loop
@@ -305,13 +297,7 @@ loop:
 
 	// The sought sample might also be in the range.
 	switch soughtValueType {
-	case chunkenc.ValHistogram:
-		t, h := it.AtHistogram()
-		if t == maxt && !value.IsStaleNaN(h.Sum) {
-			out = append(out, promql.Sample{T: t, H: h.ToFloat()})
-		}
-
-	case chunkenc.ValFloatHistogram:
+	case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
 		t, fh := it.AtFloatHistogram()
 		if t == maxt && !value.IsStaleNaN(fh.Sum) {
 			out = append(out, promql.Sample{T: t, H: fh})
@@ -379,16 +365,8 @@ loop:
 		switch buf.Next() {
 		case chunkenc.ValNone:
 			break loop
-		case chunkenc.ValHistogram:
-			t, h := buf.AtHistogram()
-			if t >= mint {
-				out = append(out, promql.Sample{T: t, H: h.ToFloat()})
-			}
-		case chunkenc.ValFloatHistogram:
+		case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
 			t, fh := buf.AtFloatHistogram()
-			if value.IsStaleNaN(fh.Sum) {
-				continue loop
-			}
 			if t >= mint {
 				out = append(out, promql.Sample{T: t, H: fh})
 			}
@@ -413,14 +391,9 @@ loop:
 
 	// The sought sample might also be in the range.
 	switch soughtValueType {
-	case chunkenc.ValHistogram:
-		t, h := it.AtHistogram()
-		if t == maxt {
-			out = append(out, promql.Sample{T: t, H: h.ToFloat()})
-		}
-	case chunkenc.ValFloatHistogram:
+	case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
 		t, fh := it.AtFloatHistogram()
-		if t == maxt && !value.IsStaleNaN(fh.Sum) {
+		if t == maxt {
 			out = append(out, promql.Sample{T: t, H: fh})
 		}
 	case chunkenc.ValFloat:


### PR DESCRIPTION
Revert sampleRing iterator bug workaround from https://github.com/thanos-community/promql-engine/pull/227. The bug was fixed in https://github.com/prometheus/prometheus/pull/12264 which is merged now and we already use the fixed prometheus version.