### PR TITLE
Adding compatibility  with prometheus 'stringlabels' build flag

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,3 +68,21 @@ jobs:
 
       - name: Run unit tests
         run: make test
+
+  test-tag-stringlabels:
+    runs-on: ubuntu-latest
+    name: Run tests --tags=stringlabels
+    env:
+      GOBIN: /tmp/.bin
+    steps:
+      - name: Check out code into the Go module directory.
+        uses: actions/checkout@v3
+
+      - name: Install Go.
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: .go-version
+          cache: true
+
+      - name: Run unit tests
+        run: make test-stringlabels

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ help: ## Displays help.
 
 .PHONY: test
 test: ## Runs all Go unit tests.
-export GOCACHE=/tmp/cache
-test:
+	@export GOCACHE=/tmp/cache
 	@echo ">> running unit tests (without cache)"
 	@rm -rf $(GOCACHE)
 	@go test -v -race -timeout=10m $(shell go list ./...);
@@ -40,8 +39,7 @@ test:
 
 .PHONY: test-stringlabels
 test-stringlabels: ## Runs all Go unit tests with stringlabels flag.
-export GOCACHE=/tmp/cache
-test-stringlabels:
+	@export GOCACHE=/tmp/cache
 	@echo ">> stringlabels: running unit tests (without cache)"
 	@rm -rf $(GOCACHE)
 	@go test -v -race --tags=stringlabels -timeout=10m $(shell go list ./...);

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,15 @@ test:
 	@rm -rf $(GOCACHE)
 	@go test -v -race -timeout=10m $(shell go list ./...);
 
+
+.PHONY: test-stringlabels
+test-stringlabels: ## Runs all Go unit tests with stringlabels flag.
+export GOCACHE=/tmp/cache
+test-stringlabels:
+	@echo ">> stringlabels: running unit tests (without cache)"
+	@rm -rf $(GOCACHE)
+	@go test -v -race --tags=stringlabels -timeout=10m $(shell go list ./...);
+
 .PHONY: deps
 deps: ## Ensures fresh go.mod and go.sum.
 	@go mod tidy

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	promparser "github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
+	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4385,8 +4385,8 @@ func roundValues(r *promql.Result) {
 func emptyLabelsToNil(result *promql.Result) {
 	if value, ok := result.Value.(promql.Matrix); ok {
 		for i, s := range value {
-			if len(s.Metric) == 0 {
-				result.Value.(promql.Matrix)[i].Metric = nil
+			if s.Metric.IsEmpty() {
+				result.Value.(promql.Matrix)[i].Metric = labels.EmptyLabels()
 			}
 		}
 	}

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -150,8 +150,8 @@ func FuzzEnginePromQLSmithInstantQuery(f *testing.F) {
 			return
 		}
 		load := fmt.Sprintf(`load 30s
-			http_requests_total{pod="nginx-1", route="/"} %.2f+%.2fx4
-			http_requests_total{pod="nginx-2", route="/"} %2.f+%.2fx4`, initialVal1, inc1, initialVal2, inc2)
+			http_requests_total{pod="nginx-1", route="/"} %.2f+%.2fx40
+			http_requests_total{pod="nginx-2", route="/"} %2.f+%.2fx40`, initialVal1, inc1, initialVal2, inc2)
 
 		opts := promql.EngineOpts{
 			Timeout:              1 * time.Hour,
@@ -179,6 +179,7 @@ func FuzzEnginePromQLSmithInstantQuery(f *testing.F) {
 		psOpts := []promqlsmith.Option{
 			promqlsmith.WithEnableOffset(true),
 			promqlsmith.WithEnableAtModifier(true),
+			promqlsmith.WithAtModifierMaxTimestamp(180 * 1000),
 		}
 		ps := promqlsmith.New(rnd, seriesSet, psOpts...)
 
@@ -294,6 +295,7 @@ func FuzzDistributedEnginePromQLSmithRangeQuery(f *testing.F) {
 		psOpts := []promqlsmith.Option{
 			promqlsmith.WithEnableOffset(true),
 			promqlsmith.WithEnableAtModifier(true),
+			promqlsmith.WithAtModifierMaxTimestamp(180 * 1000),
 			promqlsmith.WithEnabledAggrs([]parser.ItemType{parser.SUM, parser.MIN, parser.MAX, parser.GROUP, parser.COUNT, parser.BOTTOMK, parser.TOPK}),
 		}
 		ps := promqlsmith.New(rnd, seriesSet, psOpts...)
@@ -398,6 +400,7 @@ func FuzzDistributedEnginePromQLSmithInstantQuery(f *testing.F) {
 		psOpts := []promqlsmith.Option{
 			promqlsmith.WithEnableOffset(true),
 			promqlsmith.WithEnableAtModifier(true),
+			promqlsmith.WithAtModifierMaxTimestamp(180 * 1000),
 			promqlsmith.WithEnabledAggrs([]parser.ItemType{parser.SUM, parser.MIN, parser.MAX, parser.GROUP, parser.COUNT, parser.BOTTOMK, parser.TOPK}),
 		}
 		ps := promqlsmith.New(rnd, seriesSet, psOpts...)

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -467,7 +468,7 @@ var comparer = cmp.Comparer(func(x, y *promql.Result) bool {
 			return labels.Compare(vy[i].Metric, vy[j].Metric) < 0
 		})
 		for i := 0; i < len(vx); i++ {
-			if !cmp.Equal(vx[i].Metric, vy[i].Metric) {
+			if !equal(vx[i].Metric, vy[i].Metric) {
 				return false
 			}
 			if vx[i].T != vy[i].T {
@@ -494,7 +495,7 @@ var comparer = cmp.Comparer(func(x, y *promql.Result) bool {
 			mxs := mx[i]
 			mys := my[i]
 
-			if !cmp.Equal(mxs.Metric, mys.Metric) {
+			if !equal(mxs.Metric, mys.Metric) {
 				return false
 			}
 
@@ -542,4 +543,12 @@ func getSeries(ctx context.Context, q storage.Queryable) ([]labels.Labels, error
 		return nil, err
 	}
 	return res, nil
+}
+
+func equal(oldResult, newResult interface{}) bool {
+	if reflect.TypeOf(labels.Labels{}).Kind() == reflect.Struct {
+		return cmp.Equal(oldResult, newResult, cmp.AllowUnexported(labels.Labels{}))
+	} else {
+		return cmp.Equal(oldResult, newResult)
+	}
 }

--- a/engine/existing_test.go
+++ b/engine/existing_test.go
@@ -94,7 +94,7 @@ func TestRangeQuery(t *testing.T) {
 			Result: promql.Matrix{
 				promql.Series{
 					Floats: []promql.FPoint{{F: 1, T: 0}, {F: 3, T: 60000}, {F: 5, T: 120000}},
-					Metric: labels.Labels{labels.Label{Name: "__name__", Value: "metric"}},
+					Metric: labels.New(labels.Label{Name: "__name__", Value: "metric"}),
 				},
 			},
 			Start:    time.Unix(0, 0),
@@ -109,7 +109,7 @@ func TestRangeQuery(t *testing.T) {
 			Result: promql.Matrix{
 				promql.Series{
 					Floats: []promql.FPoint{{F: 1, T: 0}, {F: 3, T: 60000}, {F: 5, T: 120000}},
-					Metric: labels.Labels{labels.Label{Name: "__name__", Value: "metric"}},
+					Metric: labels.New(labels.Label{Name: "__name__", Value: "metric"}),
 				},
 			},
 			Start:    time.Unix(0, 0),

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -101,7 +101,7 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 		return nil, nil
 	}
 	if len(args) < len(in) {
-		return nil, errors.New("scalar argument not found")
+		return nil, errors.New("Scalar value NaN overflows int64")
 	}
 
 	a.once.Do(func() { err = a.init(ctx) })

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -167,7 +167,7 @@ func (o *scalarOperator) loadSeries(ctx context.Context) error {
 		if !vectorSeries[i].IsEmpty() {
 			lbls := vectorSeries[i]
 			if shouldDropMetricName(o.opType, o.returnBool) {
-				lbls, _ = function.DropMetricName(lbls.Copy(), b)
+				lbls, _ = function.DropMetricName(lbls, b)
 			}
 			series[i] = lbls
 		} else {

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -169,6 +169,8 @@ func (o *scalarOperator) loadSeries(ctx context.Context) error {
 				lbls, _ = function.DropMetricName(lbls.Copy())
 			}
 			series[i] = lbls
+		} else {
+			series[i] = vectorSeries[i]
 		}
 	}
 

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -162,11 +162,12 @@ func (o *scalarOperator) loadSeries(ctx context.Context) error {
 		return err
 	}
 	series := make([]labels.Labels, len(vectorSeries))
+	b := labels.NewScratchBuilder(function.ExpectedLabelsSize)
 	for i := range vectorSeries {
 		if !vectorSeries[i].IsEmpty() {
 			lbls := vectorSeries[i]
 			if shouldDropMetricName(o.opType, o.returnBool) {
-				lbls, _ = function.DropMetricName(lbls.Copy())
+				lbls, _ = function.DropMetricName(lbls.Copy(), b)
 			}
 			series[i] = lbls
 		} else {

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -163,7 +163,7 @@ func (o *scalarOperator) loadSeries(ctx context.Context) error {
 	}
 	series := make([]labels.Labels, len(vectorSeries))
 	for i := range vectorSeries {
-		if vectorSeries[i] != nil {
+		if !vectorSeries[i].IsEmpty() {
 			lbls := vectorSeries[i]
 			if shouldDropMetricName(o.opType, o.returnBool) {
 				lbls, _ = function.DropMetricName(lbls.Copy())

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -162,7 +162,7 @@ func (o *scalarOperator) loadSeries(ctx context.Context) error {
 		return err
 	}
 	series := make([]labels.Labels, len(vectorSeries))
-	b := labels.NewScratchBuilder(function.ExpectedLabelsSize)
+	b := labels.ScratchBuilder{}
 	for i := range vectorSeries {
 		if !vectorSeries[i].IsEmpty() {
 			lbls := vectorSeries[i]

--- a/execution/function/functions.go
+++ b/execution/function/functions.go
@@ -27,6 +27,7 @@ type FunctionArgs struct {
 	ScalarPoints     []float64
 	Offset           int64
 	MetricAppearedTs *int64
+	LabelsBuilder    labels.ScratchBuilder
 }
 
 // FunctionCall represents functions as defined in https://prometheus.io/docs/prometheus/latest/querying/functions/
@@ -938,7 +939,7 @@ func dateWrapper(fa FunctionArgs, f func(time.Time) float64) promql.Sample {
 		}
 	}
 	t := time.Unix(int64(fa.Samples[0].F), 0).UTC()
-	lbls, _ := DropMetricName(fa.Labels, labels.NewScratchBuilder(fa.Labels.Len()))
+	lbls, _ := DropMetricName(fa.Labels, fa.LabelsBuilder)
 	return promql.Sample{
 		Metric: lbls,
 		F:      f(t),

--- a/execution/function/functions.go
+++ b/execution/function/functions.go
@@ -938,7 +938,7 @@ func dateWrapper(fa FunctionArgs, f func(time.Time) float64) promql.Sample {
 		}
 	}
 	t := time.Unix(int64(fa.Samples[0].F), 0).UTC()
-	lbls, _ := DropMetricName(fa.Labels)
+	lbls, _ := DropMetricName(fa.Labels, labels.NewScratchBuilder(fa.Labels.Len()))
 	return promql.Sample{
 		Metric: lbls,
 		F:      f(t),

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -187,15 +187,15 @@ func (o *histogramOperator) loadSeries(ctx context.Context) error {
 
 	o.series = make([]labels.Labels, 0)
 	o.outputIndex = make([]*histogramSeries, len(series))
-
+	b := labels.NewScratchBuilder(ExpectedLabelsSize)
 	for i, s := range series {
 		hasBucketValue := true
-		lbls, bucketLabel := dropLabel(s.Copy(), "le")
+		lbls, bucketLabel := dropLabel(s.Copy(), "le", b)
 		value, err := strconv.ParseFloat(bucketLabel.Value, 64)
 		if err != nil {
 			hasBucketValue = false
 		}
-		lbls, _ = DropMetricName(lbls)
+		lbls, _ = DropMetricName(lbls, b)
 
 		hasher.Reset()
 		hashBuf = lbls.Bytes(hashBuf)

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -190,7 +190,7 @@ func (o *histogramOperator) loadSeries(ctx context.Context) error {
 	b := labels.ScratchBuilder{}
 	for i, s := range series {
 		hasBucketValue := true
-		lbls, bucketLabel := dropLabel(s.Copy(), "le", b)
+		lbls, bucketLabel := dropLabel(s, "le", b)
 		value, err := strconv.ParseFloat(bucketLabel.Value, 64)
 		if err != nil {
 			hasBucketValue = false

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -187,7 +187,7 @@ func (o *histogramOperator) loadSeries(ctx context.Context) error {
 
 	o.series = make([]labels.Labels, 0)
 	o.outputIndex = make([]*histogramSeries, len(series))
-	b := labels.NewScratchBuilder(ExpectedLabelsSize)
+	b := labels.ScratchBuilder{}
 	for i, s := range series {
 		hasBucketValue := true
 		lbls, bucketLabel := dropLabel(s.Copy(), "le", b)

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -329,7 +329,7 @@ func (o *functionOperator) loadSeries(ctx context.Context) error {
 
 				lbls = lb.Labels()
 			default:
-				lbls, _ = DropMetricName(s.Copy(), b)
+				lbls, _ = DropMetricName(s, b)
 			}
 			o.series[i] = lbls
 		}

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -341,24 +341,22 @@ func DropMetricName(l labels.Labels) (labels.Labels, labels.Label) {
 
 // dropLabel removes the label with name from l and returns the dropped label.
 func dropLabel(l labels.Labels, name string) (labels.Labels, labels.Label) {
-	if len(l) == 0 {
+	var ret labels.Label
+
+	if l.IsEmpty() {
 		return l, labels.Label{}
 	}
 
-	if len(l) == 1 {
-		if l[0].Name == name {
-			return l[:0], l[0]
+	b := labels.NewScratchBuilder(l.Len())
 
+	l.Range(func(l labels.Label) {
+		if l.Name == name {
+			ret = l
+			return
 		}
-		return l, labels.Label{}
-	}
 
-	for i := range l {
-		if l[i].Name == name {
-			lbl := l[i]
-			return append(l[:i], l[i+1:]...), lbl
-		}
-	}
+		b.Add(l.Name, l.Value)
+	})
 
-	return l, labels.Label{}
+	return b.Labels(), ret
 }

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -216,7 +216,7 @@ func (o *matrixSelector) loadSeries(ctx context.Context) error {
 				// we have to copy it here.
 				// TODO(GiedriusS): could we identify somehow whether labels.Labels
 				// is reused between Select() calls?
-				lbls, _ = function.DropMetricName(lbls.Copy(), b)
+				lbls, _ = function.DropMetricName(lbls, b)
 			}
 
 			// If we are dealing with an extended range function we need to search further in the past for valid series.

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -124,7 +124,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 
 	vectors := o.vectorPool.GetVectorBatch()
 	ts := o.currentStep
-	lblBuilder := labels.NewScratchBuilder(function.ExpectedLabelsSize)
+	lblBuilder := labels.ScratchBuilder{}
 	for i := 0; i < len(o.scanners); i++ {
 		var (
 			series   = o.scanners[i]
@@ -207,7 +207,7 @@ func (o *matrixSelector) loadSeries(ctx context.Context) error {
 
 		o.scanners = make([]matrixScanner, len(series))
 		o.series = make([]labels.Labels, len(series))
-		b := labels.NewScratchBuilder(function.ExpectedLabelsSize)
+		b := labels.ScratchBuilder{}
 		for i, s := range series {
 			lbls := s.Labels()
 			if o.funcExpr.Func.Name != "last_over_time" {

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -205,6 +205,7 @@ func (o *matrixSelector) loadSeries(ctx context.Context) error {
 
 		o.scanners = make([]matrixScanner, len(series))
 		o.series = make([]labels.Labels, len(series))
+		b := labels.NewScratchBuilder(function.ExpectedLabelsSize)
 		for i, s := range series {
 			lbls := s.Labels()
 			if o.funcExpr.Func.Name != "last_over_time" {
@@ -213,7 +214,7 @@ func (o *matrixSelector) loadSeries(ctx context.Context) error {
 				// we have to copy it here.
 				// TODO(GiedriusS): could we identify somehow whether labels.Labels
 				// is reused between Select() calls?
-				lbls, _ = function.DropMetricName(lbls.Copy())
+				lbls, _ = function.DropMetricName(lbls.Copy(), b)
 			}
 
 			// If we are dealing with an extended range function we need to search further in the past for valid series.

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -6,7 +6,6 @@ package scan
 import (
 	"context"
 	"fmt"
-	"sort"
 	"sync"
 	"time"
 
@@ -222,8 +221,6 @@ func (o *matrixSelector) loadSeries(ctx context.Context) error {
 			if function.IsExtFunction(o.funcExpr.Func.Name) {
 				selectRange += o.extLookbackDelta
 			}
-
-			sort.Sort(lbls)
 
 			o.scanners[i] = matrixScanner{
 				labels:    lbls,

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -124,6 +124,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 
 	vectors := o.vectorPool.GetVectorBatch()
 	ts := o.currentStep
+	lblBuilder := labels.NewScratchBuilder(function.ExpectedLabelsSize)
 	for i := 0; i < len(o.scanners); i++ {
 		var (
 			series   = o.scanners[i]
@@ -161,6 +162,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 				SelectRange:      o.selectRange,
 				Offset:           o.offset,
 				MetricAppearedTs: o.scanners[i].metricAppearedTs,
+				LabelsBuilder:    lblBuilder,
 			})
 
 			if result.T != function.InvalidSample.T {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/cespare/xxhash/v2 v2.2.0
-	github.com/cortexproject/promqlsmith v0.0.0-20230428202307-d5d38dee2020
+	github.com/cortexproject/promqlsmith v0.0.0-20230502194647-ed3e43bb7a52
 	github.com/efficientgo/core v1.0.0-rc.2
 	github.com/go-kit/log v0.2.1
 	github.com/google/go-cmp v0.5.9

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/cespare/xxhash/v2 v2.2.0
-	github.com/cortexproject/promqlsmith v0.0.0-20230313010502-5c380a3b00b0
+	github.com/cortexproject/promqlsmith v0.0.0-20230428202307-d5d38dee2020
 	github.com/efficientgo/core v1.0.0-rc.2
 	github.com/go-kit/log v0.2.1
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20230112175826-46e39c7b9b43 h1:XP+uhjN0yBCN/tPkr8Z0BNDc5rZam9RG6UWyf2FrSQ0=
-github.com/cortexproject/promqlsmith v0.0.0-20230313010502-5c380a3b00b0 h1:NxAuzQ8oCBUgmBTmhC4GyKk9kBl4IoDymGib+tVdqiQ=
-github.com/cortexproject/promqlsmith v0.0.0-20230313010502-5c380a3b00b0/go.mod h1:ngsF8Fu5zfL7q0TufnEd+QvomTblziwTKBRvb9kQ5Ic=
+github.com/cortexproject/promqlsmith v0.0.0-20230428202307-d5d38dee2020 h1:UmW8MDEPkNH5ooESvlm//nCEchpT8oQ/YpNYh7WtMqo=
+github.com/cortexproject/promqlsmith v0.0.0-20230428202307-d5d38dee2020/go.mod h1:8LOFLrqqVfNalbgjKZYdh6Bv/VXLdOV799aJwZJJGOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20230112175826-46e39c7b9b43 h1:XP+uhjN0yBCN/tPkr8Z0BNDc5rZam9RG6UWyf2FrSQ0=
-github.com/cortexproject/promqlsmith v0.0.0-20230428202307-d5d38dee2020 h1:UmW8MDEPkNH5ooESvlm//nCEchpT8oQ/YpNYh7WtMqo=
-github.com/cortexproject/promqlsmith v0.0.0-20230428202307-d5d38dee2020/go.mod h1:8LOFLrqqVfNalbgjKZYdh6Bv/VXLdOV799aJwZJJGOs=
+github.com/cortexproject/promqlsmith v0.0.0-20230502194647-ed3e43bb7a52 h1:soTzgUC/F+qtsMbh/IWr3uGwPaXXYEUsTT3zYiXP0yM=
+github.com/cortexproject/promqlsmith v0.0.0-20230502194647-ed3e43bb7a52/go.mod h1:8LOFLrqqVfNalbgjKZYdh6Bv/VXLdOV799aJwZJJGOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -144,13 +144,13 @@ func newRemoteAggregation(rootAggregation *parser.AggregateExpr, engines []api.R
 
 	for _, engine := range engines {
 		for _, lbls := range engine.LabelSets() {
-			for _, lbl := range lbls {
+			lbls.Range(func(lbl labels.Label) {
 				if rootAggregation.Without {
 					delete(groupingSet, lbl.Name)
 				} else {
 					groupingSet[lbl.Name] = struct{}{}
 				}
-			}
+			})
 		}
 	}
 
@@ -303,7 +303,7 @@ func matchesExternalLabelSet(expr parser.Expr, externalLabelSet []labels.Labels)
 
 // matchesExternalLabels returns false if given matchers are not matching external labels.
 func matchesExternalLabels(ms []*labels.Matcher, externalLabels labels.Labels) bool {
-	if len(externalLabels) == 0 {
+	if externalLabels.Len() == 0 {
 		return true
 	}
 


### PR DESCRIPTION
Making the engine compatible with the new `stringlabels` prometheus build flag.

Please note that i removed the slice.sort [here](https://github.com/thanos-community/promql-engine/compare/main...alanprot:stringlabels?expand=1#diff-71b2f22455f49b77b1e67f02bb1ff142151a8497c0125345f63b48dca946bb0cL224) but this seems to be ok as the labels should always be sorted when being contracted.

See: https://github.com/prometheus/prometheus/blob/24d7e5bd49dd26a45c2123a897c6cac5ac7c47f0/model/labels/labels.go#L365

cc @fpetkovski 