### PR TITLE
Add `NewInstantQuery` fn to RemoteEngine interface

### DIFF
--- a/api/remote.go
+++ b/api/remote.go
@@ -19,6 +19,7 @@ type RemoteEngine interface {
 	MaxT() int64
 	MinT() int64
 	LabelSets() []labels.Labels
+	NewInstantQuery(ctx context.Context, opts *promql.QueryOpts, qs string, ts time.Time) (promql.Query, error)
 	NewRangeQuery(ctx context.Context, opts *promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error)
 }
 


### PR DESCRIPTION
Add `NewInstantQuery` fn to RemoteEngine interface (as preparation to add instant query to [the Thanos remote engine](https://github.com/thanos-io/thanos/blob/f6dfd7fd75498ee80130fc8aaad50d25cd5fa8cb/pkg/query/remote_engine.go)).