### PR TITLE
tests: fix comparison for fuzzing

### DIFF
--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -452,7 +452,7 @@ var comparer = cmp.Comparer(func(x, y *promql.Result) bool {
 
 	if x.Err != nil && y.Err != nil {
 		return cmp.Equal(x.Err.Error(), y.Err.Error())
-	} else if x.Err != nil {
+	} else if x.Err != nil || y.Err != nil {
 		return false
 	}
 


### PR DESCRIPTION
fixes
```
    --- FAIL: FuzzEnginePromQLSmithInstantQuery (0.58s)
        testing.go:1485: panic: non-deterministic or non-symmetric function detected: func1

```