### PR TITLE
Fix step generation in selectors

### DIFF
--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -264,6 +264,7 @@ func BenchmarkRangeQuery(b *testing.B) {
 
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
 			b.Run("old_engine", func(b *testing.B) {
 				opts := promql.EngineOpts{
 					Logger:               nil,

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -67,13 +67,12 @@ func (o *numberLiteralSelector) Next(ctx context.Context) ([]model.StepVector, e
 
 	o.loadSeries()
 
-	vectors := o.vectorPool.GetVectorBatch()
 	ts := o.currentStep
+	vectors := o.vectorPool.GetVectorBatch()
 	for currStep := 0; currStep < o.numSteps && ts <= o.maxt; currStep++ {
-		if len(vectors) <= currStep {
-			vectors = append(vectors, o.vectorPool.GetStepVector(ts))
-		}
-		vectors[currStep].AppendSample(o.vectorPool, 0, o.val)
+		stepVector := o.vectorPool.GetStepVector(ts)
+		stepVector.AppendSample(o.vectorPool, 0, o.val)
+		vectors = append(vectors, stepVector)
 
 		ts += o.step
 	}

--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -104,8 +104,15 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 		return nil, err
 	}
 
-	vectors := o.vectorPool.GetVectorBatch()
 	ts := o.currentStep
+	vectors := o.vectorPool.GetVectorBatch()
+	for currStep := 0; currStep < o.numSteps && ts <= o.maxt; currStep++ {
+		vectors = append(vectors, o.vectorPool.GetStepVector(ts))
+		ts += o.step
+	}
+
+	// Reset the current timestamp.
+	ts = o.currentStep
 	for i := 0; i < len(o.scanners); i++ {
 		var (
 			series   = o.scanners[i]
@@ -113,9 +120,6 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 		)
 
 		for currStep := 0; currStep < o.numSteps && seriesTs <= o.maxt; currStep++ {
-			if len(vectors) <= currStep {
-				vectors = append(vectors, o.vectorPool.GetStepVector(seriesTs))
-			}
 			_, v, h, ok, err := selectPoint(series.samples, seriesTs, o.lookbackDelta, o.offset)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Selector operators have a bug where if no series for a given timestamp exists,
the step vector will not be generated for that step. This complicates
the implementation of the absent function, and could also cause subtle bugs
in downstream operators which expect all end-result steps to be present in a batch.

This commit fixes the issue by making sure all steps for a batch are generated
in the matrix and vector selectors before returning the batch.